### PR TITLE
Us 2251 redesign h2b key

### DIFF
--- a/scripts/build-and-start-server
+++ b/scripts/build-and-start-server
@@ -1,4 +1,4 @@
-#!env sh
+#!/bin/bash
 
 
 #docker run -ti docker.dbc.dk/payara-micro /bin/bash

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -105,10 +105,9 @@ public class BibliographicBean {
     }
 
     private void addHoldingsToBibliographic(int agency, String recordId, Integer holdingsAgency) {
-        HoldingsToBibliographicEntity h2b = new HoldingsToBibliographicEntity();
-        h2b.bibliographicRecordId = recordId;
-        h2b.holdingsAgencyId = holdingsAgency;
-        h2b.bibliographicAgencyId = agency;
+        HoldingsToBibliographicEntity h2b = new HoldingsToBibliographicEntity(
+                holdingsAgency, recordId,agency
+        );
         entityManager.merge(h2b);
     }
 

--- a/service/src/main/java/dk/dbc/search/solrdocstore/DocumentRetrieveBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/DocumentRetrieveBean.java
@@ -45,7 +45,7 @@ public class DocumentRetrieveBean {
                                   " INNER JOIN HoldingsItemEntity h" +
                                   " WHERE h2b.bibliographicRecordId = :bibliographicRecordId" +
                                   " AND h2b.bibliographicAgencyId = :agencyId" +
-                                  " AND h2b.bibliographicRecordId = h.bibliographicRecordId" +
+                                  " AND h2b.holdingsBibliographicRecordId = h.bibliographicRecordId" +
                                   " AND h2b.holdingsAgencyId = h.agencyId";
 
     @PersistenceContext(unitName = "solrDocumentStore_PU")

--- a/service/src/main/java/dk/dbc/search/solrdocstore/FrontendAPIBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/FrontendAPIBean.java
@@ -28,7 +28,7 @@ public class FrontendAPIBean {
 
     /**
      * Returns a json object with a result field, which is a list of json BibliographicEntity that matches
-     * bibliographicRecordId with the argument.
+     * holdingsBibliographicRecordId with the argument.
      * @param bibliographicRecordId path parameter, expects URI encoding
      * @return Response
      */

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBean.java
@@ -91,11 +91,11 @@ public class HoldingsToBibliographicBean {
     }
 
     private HoldingsToBibliographicEntity createH2B(int attachToAgency, HoldingsToBibliographicKey itemKey) {
-        HoldingsToBibliographicEntity newEntity = new HoldingsToBibliographicEntity();
-        newEntity.holdingsAgencyId = itemKey.holdingsAgencyId;
-        newEntity.bibliographicRecordId = itemKey.bibliographicRecordId;
-        newEntity.bibliographicAgencyId = attachToAgency;
-        return newEntity;
+        return new HoldingsToBibliographicEntity(
+                itemKey.holdingsAgencyId,
+                itemKey.holdingsBibliographicRecordId,
+                attachToAgency
+        );
     }
 
     private void addAttachEventQueue(int bibliographicAgencyId, String bibliographicRecordId) {

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicEntity.java
@@ -1,6 +1,5 @@
 package dk.dbc.search.solrdocstore;
 
-import javax.persistence.Column;
 import javax.persistence.Entity;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
@@ -14,16 +13,33 @@ public class HoldingsToBibliographicEntity {
     @Id
     public int holdingsAgencyId;
     @Id
+    public String holdingsBibliographicRecordId;
+
     public String bibliographicRecordId;
     public int bibliographicAgencyId;
 
     public HoldingsToBibliographicEntity() {
     }
 
-    HoldingsToBibliographicEntity(int agencyId, String bibliographicRecordId, int bibliographicAgencyId) {
-        this.holdingsAgencyId = agencyId;
+    HoldingsToBibliographicEntity(int holdingsAgencyId, String bibliographicRecordId, int bibliographicAgencyId) {
+        this(holdingsAgencyId,bibliographicRecordId, bibliographicAgencyId, bibliographicRecordId);
+    }
+
+    public HoldingsToBibliographicEntity(int holdingsAgencyId, String holdingsBibliographicRecordId, int bibliographicAgencyId, String bibliographicRecordId) {
+        this.holdingsAgencyId = holdingsAgencyId;
+        this.holdingsBibliographicRecordId = holdingsBibliographicRecordId;
         this.bibliographicRecordId = bibliographicRecordId;
         this.bibliographicAgencyId = bibliographicAgencyId;
+    }
+
+    @Override
+    public String toString() {
+        return "HoldingsToBibliographicEntity{" +
+                "holdingsAgencyId=" + holdingsAgencyId +
+                ", holdingsBibliographicRecordId='" + holdingsBibliographicRecordId + '\'' +
+                ", holdingsBibliographicRecordId='" + bibliographicRecordId + '\'' +
+                ", bibliographicAgencyId=" + bibliographicAgencyId +
+                '}';
     }
 
     @Override
@@ -33,20 +49,13 @@ public class HoldingsToBibliographicEntity {
         HoldingsToBibliographicEntity that = (HoldingsToBibliographicEntity) o;
         return holdingsAgencyId == that.holdingsAgencyId &&
                 bibliographicAgencyId == that.bibliographicAgencyId &&
+                Objects.equals(holdingsBibliographicRecordId, that.holdingsBibliographicRecordId) &&
                 Objects.equals(bibliographicRecordId, that.bibliographicRecordId);
     }
 
     @Override
     public int hashCode() {
-        return Objects.hash(holdingsAgencyId, bibliographicRecordId, bibliographicAgencyId);
-    }
 
-    @Override
-    public String toString() {
-        return "HoldingsToBibliographicEntity{" +
-                "holdingsAgencyId=" + holdingsAgencyId +
-                ", bibliographicRecordId='" + bibliographicRecordId + '\'' +
-                ", bibliographicAgencyId=" + bibliographicAgencyId +
-                '}';
+        return Objects.hash(holdingsAgencyId, holdingsBibliographicRecordId, bibliographicRecordId, bibliographicAgencyId);
     }
 }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicKey.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicKey.java
@@ -7,21 +7,21 @@ public class HoldingsToBibliographicKey implements Serializable {
     private static final long serialVersionUID = -2054293971622143423L;
 
     public int holdingsAgencyId;
-    public String bibliographicRecordId;
+    public String holdingsBibliographicRecordId;
 
     public HoldingsToBibliographicKey() {
     }
 
     public HoldingsToBibliographicKey(int holdingsAgencyId, String bibliographicRecordId) {
         this.holdingsAgencyId = holdingsAgencyId;
-        this.bibliographicRecordId = bibliographicRecordId;
+        this.holdingsBibliographicRecordId = bibliographicRecordId;
     }
     public HoldingsToBibliographicKey withHoldingAgencyId(int agencyId){
         this.holdingsAgencyId = agencyId;
         return this;
     }
     public HoldingsToBibliographicKey withHoldingsBibliographicRecordId(String bibliographicRecordId){
-        this.bibliographicRecordId = bibliographicRecordId;
+        this.holdingsBibliographicRecordId = bibliographicRecordId;
         return this;
     }
 
@@ -31,12 +31,12 @@ public class HoldingsToBibliographicKey implements Serializable {
         if (o == null || getClass() != o.getClass()) return false;
         HoldingsToBibliographicKey that = (HoldingsToBibliographicKey) o;
         return holdingsAgencyId == that.holdingsAgencyId &&
-                Objects.equals(bibliographicRecordId, that.bibliographicRecordId);
+                Objects.equals(holdingsBibliographicRecordId, that.holdingsBibliographicRecordId);
     }
 
     @Override
     public int hashCode() {
 
-        return Objects.hash(holdingsAgencyId, bibliographicRecordId);
+        return Objects.hash(holdingsAgencyId, holdingsBibliographicRecordId);
     }
 }

--- a/service/src/main/resources/db/migration/V1__Initial-schema.sql
+++ b/service/src/main/resources/db/migration/V1__Initial-schema.sql
@@ -44,10 +44,11 @@ CREATE TABLE holdingsItemsSolrKeys (
 
 CREATE TABLE holdingsToBibliographic (
     holdingsAgencyId NUMERIC(6) NOT NULL,
-    bibliographicRecordId TEXT NOT NULL,
+    holdingsBibliographicRecordId TEXT NOT NULL,
     bibliographicAgencyId NUMERIC(6) NOT NULL,
+    bibliographicRecordId TEXT NOT NULL,
 
-    PRIMARY KEY (holdingsAgencyId, bibliographicRecordId)
+    PRIMARY KEY (holdingsAgencyId, holdingsBibliographicRecordId)
 );
 
 CREATE INDEX holdingsToBibliographic_Bibliographic

--- a/service/src/test/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBeanIT.java
@@ -134,10 +134,11 @@ public class HoldingsToBibliographicBeanIT extends JpaSolrDocStoreIntegrationTes
 
     private void createH2BRecord(int agencyId, String bibliographicRecordId, int bibliographicAgencyId) {
         env().getPersistenceContext().run( () -> {
-           HoldingsToBibliographicEntity e = new HoldingsToBibliographicEntity();
-           e.holdingsAgencyId = agencyId;
-           e.bibliographicRecordId = bibliographicRecordId;
-           e.bibliographicAgencyId = bibliographicAgencyId;
+           HoldingsToBibliographicEntity e = new HoldingsToBibliographicEntity(
+                   agencyId,
+                   bibliographicRecordId,
+                   bibliographicAgencyId
+           );
            em.merge(e);
         });
     }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicEntityIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicEntityIT.java
@@ -13,10 +13,11 @@ public class HoldingsToBibliographicEntityIT extends JpaSolrDocStoreIntegrationT
         EntityManager em=env().getEntityManager();
 
         env().getPersistenceContext().run( () -> {
-            HoldingsToBibliographicEntity h2b=new HoldingsToBibliographicEntity();
-            h2b.holdingsAgencyId = 300;
-            h2b.bibliographicRecordId = "4321";
-            h2b.bibliographicAgencyId = 200;
+            HoldingsToBibliographicEntity h2b=new HoldingsToBibliographicEntity(
+                    300,
+                    "4321",
+                    200
+            );
             em.persist(h2b);
         });
     }

--- a/service/src/test/resources/entityTestData.sql
+++ b/service/src/test/resources/entityTestData.sql
@@ -9,6 +9,6 @@ INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, P
      VALUES ( 600, '600', '[{"id": ["argle"], "title": ["unix bogen"]}, {"id": ["argle"], "dyr": ["hest"], "title": ["unix bogen"]}]'::jsonb, 'revision','track');
 
 
-INSERT INTO holdingsTobibliographic (holdingsagencyid, bibliographicrecordid, bibliographicagencyid) VALUES (600, '600', 100);
+INSERT INTO holdingsTobibliographic (holdingsagencyid,holdingsbibliographicrecordid, bibliographicagencyid, bibliographicrecordid ) VALUES (600, '600', 100,'600');
 
 INSERT INTO bibliographictobibliographic (decommissionedRecordId, currentRecordId) VALUES ('399', '600');


### PR DESCRIPTION
This one might cause problems in other branches:
HoldingsToBibliographicEntity primary key will be changes from (holdingsAgencyId, bibliographicRecordId) to (holdingsAgencyId, holdingsBibliographicRecordId).

Note that bibliographicRecordId still exists in the Entity. (and holdingsBibliographicRecordId will default to bibliographicRecordId in 3-parameter Constructor).