### PR TITLE
Us 2249

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
@@ -8,6 +8,7 @@ import javax.persistence.IdClass;
 import javax.persistence.Table;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 
 import org.eclipse.persistence.annotations.Mutable;
 
@@ -48,6 +49,26 @@ public class BibliographicEntity implements Serializable {
         this.deleted = deleted;
         this.indexKeys = indexKeys;
         this.trackingId = trackingId;
+    }
+
+    @Override
+    public boolean equals(Object o){
+        System.out.println("Am I being called?");
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        System.out.println("Same class?");
+        BibliographicEntity that = (BibliographicEntity) o;
+        System.out.println(""+this.toString()+" vs. "+o.toString());
+        boolean result = agencyId == that.agencyId &&
+                Objects.equals(bibliographicRecordId, that.bibliographicRecordId) &&
+                Objects.equals(work, that.work) &&
+                Objects.equals(unit, that.unit) &&
+                Objects.equals(producerVersion, that.producerVersion) &&
+                deleted == that.deleted &&
+                Objects.equals(indexKeys,that.indexKeys) &&
+                Objects.equals(trackingId, that.trackingId);
+        System.out.println("Result: "+result);
+        return result;
     }
 
     /**

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
@@ -53,13 +53,10 @@ public class BibliographicEntity implements Serializable {
 
     @Override
     public boolean equals(Object o){
-        System.out.println("Am I being called?");
         if (this == o) return true;
         if (o == null || getClass() != o.getClass()) return false;
-        System.out.println("Same class?");
         BibliographicEntity that = (BibliographicEntity) o;
-        System.out.println(""+this.toString()+" vs. "+o.toString());
-        boolean result = agencyId == that.agencyId &&
+        return agencyId == that.agencyId &&
                 Objects.equals(bibliographicRecordId, that.bibliographicRecordId) &&
                 Objects.equals(work, that.work) &&
                 Objects.equals(unit, that.unit) &&
@@ -67,8 +64,6 @@ public class BibliographicEntity implements Serializable {
                 deleted == that.deleted &&
                 Objects.equals(indexKeys,that.indexKeys) &&
                 Objects.equals(trackingId, that.trackingId);
-        System.out.println("Result: "+result);
-        return result;
     }
 
     /**

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsToBibliographicBean.java
@@ -76,13 +76,22 @@ public class HoldingsToBibliographicBean {
         return t;
     }
 
-    private List<HoldingsToBibliographicEntity> findRecalcCandidates(String bibliographicRecordId) {
+    public List<HoldingsToBibliographicEntity> findRecalcCandidates(String bibliographicRecordId) {
 
         Query q = entityManager.createQuery(
                 "SELECT h FROM HoldingsToBibliographicEntity h " +
                         "WHERE h.bibliographicRecordId = :recId", HoldingsToBibliographicEntity.class);
         q.setParameter("recId", bibliographicRecordId);
         return  q.getResultList();
+    }
+
+    public List<HoldingsToBibliographicEntity> getRelatedHoldingsToBibliographic(int bibliographicAgencyId, String bibliographicRecordId){
+        return entityManager.createQuery(
+                "SELECT h FROM HoldingsToBibliographicEntity h WHERE " +
+                        "h.bibliographicRecordId=:bibId and " +
+                        "h.bibliographicAgencyId=:agencyId", HoldingsToBibliographicEntity.class)
+                .setParameter("agencyId",bibliographicAgencyId)
+                .setParameter("bibId",bibliographicRecordId).getResultList();
     }
 
     private String supersede(String bibliographicRecordId) {

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -141,23 +141,37 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
      */
     @Test
     public void deleteUpdateHoldings() throws JSONBException {
+        // Before common FBS update
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onDelete");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600200,"onDelete",600200),
+                new HoldingsToBibliographicEntity(620520,"onDelete",600200),
+                new HoldingsToBibliographicEntity(620521,"onDelete",600521)
+        ));
         // Update common for FBS
         runDeleteUpdate(600200,"onDelete",true);
 
         // Ensure related holdings are moved to a higher level
-        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onDelete");
+        l = getRelatedHoldings("onDelete");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(600200,"onDelete",870970),
                 new HoldingsToBibliographicEntity(620520,"onDelete",870970),
                 new HoldingsToBibliographicEntity(620521,"onDelete",600521)
         ));
-        // Update common FBS School
+        // Before common FBS School update
+        l = getRelatedHoldings("onDeleteSchool");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(320520,"onDeleteSchool",300200),
+                new HoldingsToBibliographicEntity(320521,"onDeleteSchool",870970)
+        ));
+        // Update common FBS School, moved one level up
         runDeleteUpdate(300200,"onDeleteSchool",true);
         l = getRelatedHoldings("onDeleteSchool");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(320520,"onDeleteSchool",870970),
                 new HoldingsToBibliographicEntity(320521,"onDeleteSchool",870970)
         ));
+        // Update common FBS School, moved up yet again
         runDeleteUpdate(870970,"onDeleteSchool",true);
         l = getRelatedHoldings("onDeleteSchool");
         assertThat(l,containsInAnyOrder(
@@ -182,13 +196,23 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
      */
     @Test
     public void recreateUpdateHoldings() throws JSONBException {
+        // Before update
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreate");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600300,"onRecreate",870970)
+        ));
         // Recreate FBS library
         runDeleteUpdate(600300,"onRecreate",false);
 
-        // Ensure related holdings are moved to a higher level
-        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreate");
+        // Ensure related holdings are moved back to their lower level
+        l = getRelatedHoldings("onRecreate");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(600300,"onRecreate",600300)
+        ));
+        // Before update of FBS School
+        l = getRelatedHoldings("onRecreateSchool");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300300,"onRecreateSchool",300000)
         ));
         // Recreate FBS School
         runDeleteUpdate(300300,"onRecreateSchool",false);
@@ -198,10 +222,8 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(300300,"onRecreateSchool",300300)
         ));
-        // Recreate no descendants
+        // Recreate no holdings on lower level, nothing is moved
         runDeleteUpdate(655555,"onRecreateSingle",false);
-
-        // Ensure related holdings are moved to a higher level
         l = getRelatedHoldings("onRecreateSingle");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(607000,"onRecreateSingle",655555)
@@ -210,15 +232,29 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
 
     @Test
     public void deleteUpdateHoldingsSupersede() throws JSONBException {
-        // Delete update FBS
-        runDeleteUpdate(600400,"onDeleteSupersedeNew",true);
+        // Before supersede update FBS
         List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onDeleteSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600400,"onDeleteSupersede",600400,"onDeleteSupersedeNew"),
+                new HoldingsToBibliographicEntity(600401,"onDeleteSupersede",600400,"onDeleteSupersedeNew"),
+                new HoldingsToBibliographicEntity(600402,"onDeleteSupersede",600400,"onDeleteSupersedeNew")
+        ));
+        // Delete update FBS, records moved to higher level
+        runDeleteUpdate(600400,"onDeleteSupersedeNew",true);
+        l = getRelatedHoldings("onDeleteSupersedeNew");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(600400,"onDeleteSupersede",870970,"onDeleteSupersedeNew"),
                 new HoldingsToBibliographicEntity(600401,"onDeleteSupersede",870970,"onDeleteSupersedeNew"),
                 new HoldingsToBibliographicEntity(600402,"onDeleteSupersede",870970,"onDeleteSupersedeNew")
         ));
-        // Delete update FBS School
+        // Before supersede update FBS School
+        l = getRelatedHoldings("onDeleteSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300400,"onDeleteSchoolSupersede",300400,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300401,"onDeleteSchoolSupersede",300400,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300402,"onDeleteSchoolSupersede",300400,"onDeleteSchoolSupersedeNew")
+        ));
+        // Delete update FBS School, moved to higher level
         runDeleteUpdate(300400,"onDeleteSchoolSupersedeNew",true);
         l = getRelatedHoldings("onDeleteSchoolSupersedeNew");
         assertThat(l,containsInAnyOrder(
@@ -237,13 +273,27 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
 
     @Test
     public void recreateUpdateHoldingsSupersede() throws JSONBException {
+        // Before FBS re-create
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreateSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600500,"onRecreateSupersede",870970,"onRecreateSupersedeNew"),
+                new HoldingsToBibliographicEntity(600501,"onRecreateSupersede",870970,"onRecreateSupersedeNew"),
+                new HoldingsToBibliographicEntity(600502,"onRecreateSupersede",600502,"onRecreateSupersedeNew")
+        ));
         // Re-create FBS
         runDeleteUpdate(600500,"onRecreateSupersedeNew",false);
-        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreateSupersedeNew");
+        l = getRelatedHoldings("onRecreateSupersedeNew");
         assertThat(l,containsInAnyOrder(
                 new HoldingsToBibliographicEntity(600500,"onRecreateSupersede",600500,"onRecreateSupersedeNew"),
                 new HoldingsToBibliographicEntity(600501,"onRecreateSupersede",870970,"onRecreateSupersedeNew"),
                 new HoldingsToBibliographicEntity(600502,"onRecreateSupersede",600502,"onRecreateSupersedeNew")
+        ));
+        // Before FBS School re-create
+        l = getRelatedHoldings("onRecreateSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300500,"onRecreateSchoolSupersede",300000,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300501,"onRecreateSchoolSupersede",300000,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300502,"onRecreateSchoolSupersede",300000,"onRecreateSchoolSupersedeNew")
         ));
         // Re-create FBSSchool
         runDeleteUpdate(870970,"onRecreateSchoolSupersedeNew",false);

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -8,7 +8,11 @@ import org.junit.Test;
 
 import javax.persistence.EntityManager;
 import javax.ws.rs.core.Response;
+import java.io.File;
+import java.net.URISyntaxException;
+import java.net.URL;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.function.Consumer;
 
@@ -23,7 +27,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
     private final JSONBContext jsonbContext = new JSONBContext();
 
     @Before
-    public void setupBean() {
+    public void setupBean() throws URISyntaxException {
         bean = new BibliographicBean();
         em = env().getEntityManager();
         bean.entityManager = em;
@@ -102,11 +106,181 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
 
         l = em.createQuery("SELECT h FROM HoldingsToBibliographicEntity as h WHERE h.bibliographicRecordId='new'", HoldingsToBibliographicEntity.class).getResultList();
         assertThat(l, containsInAnyOrder(
-                   new HoldingsToBibliographicEntity(700000, "new", 700000),
-                   new HoldingsToBibliographicEntity(700100, "new", 870970),
-                   new HoldingsToBibliographicEntity(300100, "new", 300100),
-                   new HoldingsToBibliographicEntity(300200, "new", 300000)
-           ));
+                new HoldingsToBibliographicEntity(700000, "new", 700000),
+                new HoldingsToBibliographicEntity(700100, "new", 870970),
+                new HoldingsToBibliographicEntity(300100, "new", 300100),
+                new HoldingsToBibliographicEntity(300200, "new", 300000)
+        ));
+    }
+
+    @Test
+    public void updateExistingBibliographicPost() throws JSONBException {
+        BibliographicEntity b = new BibliographicEntity(600100,"properUpdate","work:update","unit:update","prod:update",false,new HashMap<>(),"track:update");
+        String updatedB = jsonbContext.marshall(b);
+
+        Response r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(null, updatedB)
+                );
+        assertThat(r.getStatus(), is(200));
+
+        // Ensure update came through
+        BibliographicEntity updatedBibEntity = em.find(BibliographicEntity.class, new AgencyItemKey(b.agencyId, b.bibliographicRecordId));
+        assertThat(updatedBibEntity,equalTo(b));
+        //assertThat(true,equalTo(true));
+
+        // Ensure related holdings are unchanged
+        List<HoldingsToBibliographicEntity> l = em.createQuery("SELECT h FROM HoldingsToBibliographicEntity h WHERE h.bibliographicRecordId='properUpdate'", HoldingsToBibliographicEntity.class).getResultList();
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(610510,"properUpdate",600100)
+        ));
+    }
+
+    /**
+     * If a bibliographic post (all types) goes from deleted: false -> true, that bibliographic holdings are properly updated
+     * @throws JSONBException
+     */
+    @Test
+    public void deleteUpdateHoldings() throws JSONBException {
+        // Update common for FBS
+        runDeleteUpdate(600200,"onDelete",true);
+
+        // Ensure related holdings are moved to a higher level
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onDelete");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600200,"onDelete",870970),
+                new HoldingsToBibliographicEntity(620520,"onDelete",870970),
+                new HoldingsToBibliographicEntity(620521,"onDelete",600521)
+        ));
+        // Update common FBS School
+        runDeleteUpdate(300200,"onDeleteSchool",true);
+        l = getRelatedHoldings("onDeleteSchool");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(320520,"onDeleteSchool",870970),
+                new HoldingsToBibliographicEntity(320521,"onDeleteSchool",870970)
+        ));
+        runDeleteUpdate(870970,"onDeleteSchool",true);
+        l = getRelatedHoldings("onDeleteSchool");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(320520,"onDeleteSchool",300000),
+                new HoldingsToBibliographicEntity(320521,"onDeleteSchool",300000)
+        ));
+
+        // Update single record (no ancestor) holdings does not change
+        runDeleteUpdate(633333,"onDeleteSingle",true);
+
+        // Ensure related holdings no ancestor does not change
+        l = getRelatedHoldings("onDeleteSingle");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(644444,"onDeleteSingle",633333)
+        ));
+
+    }
+
+    /**
+     * If a bibliographic post (all types) goes from deleted: true -> false, that bibliographic holdings are properly updated
+     * @throws JSONBException
+     */
+    @Test
+    public void recreateUpdateHoldings() throws JSONBException {
+        // Recreate FBS library
+        runDeleteUpdate(600300,"onRecreate",false);
+
+        // Ensure related holdings are moved to a higher level
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreate");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600300,"onRecreate",600300)
+        ));
+        // Recreate FBS School
+        runDeleteUpdate(300300,"onRecreateSchool",false);
+
+        // Ensure related holdings are moved to a higher level
+        l = getRelatedHoldings("onRecreateSchool");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300300,"onRecreateSchool",300300)
+        ));
+        // Recreate no descendants
+        runDeleteUpdate(655555,"onRecreateSingle",false);
+
+        // Ensure related holdings are moved to a higher level
+        l = getRelatedHoldings("onRecreateSingle");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(607000,"onRecreateSingle",655555)
+        ));
+    }
+
+    @Test
+    public void deleteUpdateHoldingsSupersede() throws JSONBException {
+        // Delete update FBS
+        runDeleteUpdate(600400,"onDeleteSupersedeNew",true);
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onDeleteSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600400,"onDeleteSupersede",870970,"onDeleteSupersedeNew"),
+                new HoldingsToBibliographicEntity(600401,"onDeleteSupersede",870970,"onDeleteSupersedeNew"),
+                new HoldingsToBibliographicEntity(600402,"onDeleteSupersede",870970,"onDeleteSupersedeNew")
+        ));
+        // Delete update FBS School
+        runDeleteUpdate(300400,"onDeleteSchoolSupersedeNew",true);
+        l = getRelatedHoldings("onDeleteSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300400,"onDeleteSchoolSupersede",870970,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300401,"onDeleteSchoolSupersede",870970,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300402,"onDeleteSchoolSupersede",870970,"onDeleteSchoolSupersedeNew")
+        ));
+        runDeleteUpdate(870970,"onDeleteSchoolSupersedeNew",true);
+        l = getRelatedHoldings("onDeleteSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300400,"onDeleteSchoolSupersede",300000,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300401,"onDeleteSchoolSupersede",300000,"onDeleteSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300402,"onDeleteSchoolSupersede",300000,"onDeleteSchoolSupersedeNew")
+        ));
+    }
+
+    @Test
+    public void recreateUpdateHoldingsSupersede() throws JSONBException {
+        // Re-create FBS
+        runDeleteUpdate(600500,"onRecreateSupersedeNew",false);
+        List<HoldingsToBibliographicEntity> l = getRelatedHoldings("onRecreateSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(600500,"onRecreateSupersede",600500,"onRecreateSupersedeNew"),
+                new HoldingsToBibliographicEntity(600501,"onRecreateSupersede",870970,"onRecreateSupersedeNew"),
+                new HoldingsToBibliographicEntity(600502,"onRecreateSupersede",600502,"onRecreateSupersedeNew")
+        ));
+        // Re-create FBSSchool
+        runDeleteUpdate(870970,"onRecreateSchoolSupersedeNew",false);
+        l = getRelatedHoldings("onRecreateSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300500,"onRecreateSchoolSupersede",870970,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300501,"onRecreateSchoolSupersede",870970,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300502,"onRecreateSchoolSupersede",870970,"onRecreateSchoolSupersedeNew")
+        ));
+        runDeleteUpdate(300500,"onRecreateSchoolSupersedeNew",false);
+        l = getRelatedHoldings("onRecreateSchoolSupersedeNew");
+        assertThat(l,containsInAnyOrder(
+                new HoldingsToBibliographicEntity(300500,"onRecreateSchoolSupersede",300500,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300501,"onRecreateSchoolSupersede",870970,"onRecreateSchoolSupersedeNew"),
+                new HoldingsToBibliographicEntity(300502,"onRecreateSchoolSupersede",870970,"onRecreateSchoolSupersedeNew")
+        ));
+    }
+
+    /**
+     * Ensures field updates that are not deleted will not update holdings in any way,
+     * for non fbs libraries
+     * @throws JSONBException
+     */
+    @Test
+    public void deleteNoHoldings() throws JSONBException {
+        // Assure no exceptions thrown, for any type of library
+        runDeleteUpdate(780780,"onDeleteNoHoldings",true);
+        runDeleteUpdate(780780,"onDeleteNoHoldings",false);
+
+        runDeleteUpdate(340340,"onDeleteNoHoldings2",true);
+        runDeleteUpdate(340340,"onDeleteNoHoldings2",false);
+
+        runDeleteUpdate(870970,"onDeleteNoHoldings3",true);
+        runDeleteUpdate(870970,"onDeleteNoHoldings3",false);
+
+        runDeleteUpdate(300000,"onDeleteNoHoldings4",true);
+        runDeleteUpdate(300000,"onDeleteNoHoldings4",false);
     }
 
     @Test
@@ -156,6 +330,23 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         assertThat(l.size(), is(2));
         Assert.assertTrue("One superceded named 'a'", l.stream().anyMatch(b2b -> b2b.decommissionedRecordId.equals("a")));
         Assert.assertTrue("One superceded named 'b'", l.stream().anyMatch(b2b -> b2b.decommissionedRecordId.equals("b")));
+    }
+
+    public void runDeleteUpdate(int agencyId, String bibliographicRecordId, boolean deleted) throws JSONBException {
+        BibliographicEntity b = new BibliographicEntity(agencyId,bibliographicRecordId,"work:update","unit:update","prod:update",deleted,new HashMap<>(),"track:update");
+        String deletedB = jsonbContext.marshall(b);
+
+        Response r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(null, deletedB)
+                );
+        assertThat(r.getStatus(), is(200));
+    }
+
+    public List<HoldingsToBibliographicEntity> getRelatedHoldings(String bibId) {
+        return em.createQuery("SELECT h FROM HoldingsToBibliographicEntity as h WHERE h.bibliographicRecordId=:bibId",
+                HoldingsToBibliographicEntity.class)
+                .setParameter("bibId",bibId)
+                .getResultList();
     }
 
     private String makeBibliographicRequestJson(int agency) throws JSONBException {

--- a/service/src/test/resources/bibliographicUpdate.sql
+++ b/service/src/test/resources/bibliographicUpdate.sql
@@ -73,3 +73,202 @@ VALUES (300200, 'new', '[]' :: JSONB, 'revision', 'track');
 
 INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
 VALUES (800000, 'new', '[]' :: JSONB, 'revision', 'track');
+
+
+-- Values for testing proper holdings update
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600100, 'properUpdate', FALSE, '{}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (610510,'properUpdate','properUpdate',600100);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (610510, 'properUpdate', '[]' :: JSONB, 'revision', 'track');
+
+-- Values for testing proper holdings update on delete
+-- FBS
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onDelete', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600521, 'onDelete', FALSE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600200, 'onDelete', FALSE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600200,'onDelete','onDelete',600200);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (620520,'onDelete','onDelete',600200);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (620521,'onDelete','onDelete',600521);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (620520, 'onDelete', '[]' :: JSONB, 'revision', 'track');
+--INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+--VALUES (620521, 'onDelete', '[]' :: JSONB, 'revision', 'track');
+-- FBS School
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300000, 'onDeleteSchool', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onDeleteSchool', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300200, 'onDeleteSchool', FALSE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (320520,'onDeleteSchool','onDeleteSchool',300200);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (320521,'onDeleteSchool','onDeleteSchool',870970);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (320520, 'onDeleteSchool', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (320521, 'onDeleteSchool', '[]' :: JSONB, 'revision', 'track');
+-- No ancestor
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (633333, 'onDeleteSingle', FALSE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (644444,'onDeleteSingle','onDeleteSingle',633333);
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (644444, 'onDeleteSingle', '[]' :: JSONB, 'revision', 'track');
+
+
+-- Values for testing proper holdings update on recreate
+-- FBS
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onRecreate', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600300, 'onRecreate', TRUE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600300,'onRecreate','onRecreate',870970);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600300, 'onRecreate', '[]' :: JSONB, 'revision', 'track');
+-- FBS School
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300000, 'onRecreateSchool', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300300, 'onRecreateSchool', TRUE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300300,'onRecreateSchool','onRecreateSchool',300000);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (300300, 'onRecreateSchool', '[]' :: JSONB, 'revision', 'track');
+-- No ancestor
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (655555, 'onRecreateSingle', TRUE, '{"something": ["true"]}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (607000,'onRecreateSingle','onRecreateSingle',655555);
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600700, 'onRecreateSingle', '[]' :: JSONB, 'revision', 'track');
+
+-- No related holdings
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (780780, 'onDeleteNoHoldings', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (340340, 'onDeleteNoHoldings2', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onDeleteNoHoldings3', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300000, 'onDeleteNoHoldings4', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+-- Delete supersede FBS
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onDeleteSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600400, 'onDeleteSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600400,'onDeleteSupersede','onDeleteSupersedeNew',600400);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600401,'onDeleteSupersede','onDeleteSupersedeNew',600400);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600402,'onDeleteSupersede','onDeleteSupersedeNew',600400);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600400, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600401, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600402, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+
+INSERT INTO bibliographicToBibliographic (DECOMMISSIONEDRECORDID,CURRENTRECORDID)
+VALUES ('onDeleteSupersede','onDeleteSupersedeNew');
+-- Delete supersede FBSSchool
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300000, 'onDeleteSchoolSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onDeleteSchoolSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300400, 'onDeleteSchoolSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300400,'onDeleteSchoolSupersede','onDeleteSchoolSupersedeNew',300400);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300401,'onDeleteSchoolSupersede','onDeleteSchoolSupersedeNew',300400);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300402,'onDeleteSchoolSupersede','onDeleteSchoolSupersedeNew',300400);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (300400, 'onDeleteSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (300401, 'onDeleteSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (300402, 'onDeleteSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+
+INSERT INTO bibliographicToBibliographic (DECOMMISSIONEDRECORDID,CURRENTRECORDID)
+VALUES ('onDeleteSchoolSupersede','onDeleteSchoolSupersedeNew');
+
+-- Re-create supersede FBS
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onRecreateSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600500, 'onRecreateSupersedeNew', TRUE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600502, 'onRecreateSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600500,'onRecreateSupersede','onRecreateSupersedeNew',870970);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600501,'onRecreateSupersede','onRecreateSupersedeNew',870970);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (600502,'onRecreateSupersede','onRecreateSupersedeNew',600502);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600500, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600501, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600502, 'onDeleteSupersede', '[]' :: JSONB, 'revision', 'track');
+
+INSERT INTO bibliographicToBibliographic (DECOMMISSIONEDRECORDID,CURRENTRECORDID)
+VALUES ('onRecreateSupersede','onRecreateSupersedeNew');
+-- Re-create supersede FBSSchool
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300000, 'onRecreateSchoolSupersedeNew', FALSE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (870970, 'onRecreateSchoolSupersedeNew', TRUE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300500, 'onRecreateSchoolSupersedeNew', TRUE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (300502, 'onRecreateSchoolSupersedeNew', TRUE, '{"somethingElse": ["true"]}' :: JSONB, '5544:higher', 'track:higher', 'unit:higher', 'work:higher');
+
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300500,'onRecreateSchoolSupersede','onRecreateSchoolSupersedeNew',300000);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300501,'onRecreateSchoolSupersede','onRecreateSchoolSupersedeNew',300000);
+INSERT INTO holdingsToBibliographic (HOLDINGSAGENCYID, HOLDINGSBIBLIOGRAPHICRECORDID, BIBLIOGRAPHICRECORDID, BIBLIOGRAPHICAGENCYID)
+VALUES (300502,'onRecreateSchoolSupersede','onRecreateSchoolSupersedeNew',300000);
+
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600500, 'onRecreateSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600501, 'onRecreateSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
+VALUES (600502, 'onRecreateSchoolSupersede', '[]' :: JSONB, 'revision', 'track');
+
+INSERT INTO bibliographicToBibliographic (DECOMMISSIONEDRECORDID,CURRENTRECORDID)
+VALUES ('onRecreateSchoolSupersede','onRecreateSchoolSupersedeNew');
+


### PR DESCRIPTION
Når man sletter en bibliografisk post skal beholdningerne på den post rykkes op på højere niveau, og ved genoprettelse skal de rykkes ned igen.

Jeg har så vidt muligt benyttet den eksisterende kode i HoldingsToBibliographicBean.