### PR TITLE
API lazy load fix

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -66,7 +66,7 @@ public class BibliographicBean {
     public List<BibliographicEntity> getBibliographicEntitiesWithIndexKeys(String bibliographicRecordId) {
         TypedQuery<BibliographicEntity> query = entityManager.createQuery("SELECT b FROM BibliographicEntity b " +
                 "WHERE b.bibliographicRecordId = :bibId",BibliographicEntity.class)
-                .setHint("javax.persistence.fetchgraph",entityManager.getEntityGraph("bibPostWithIndexKeys"));
+                .setHint("javax.persistence.loadgraph",entityManager.getEntityGraph("bibPostWithIndexKeys"));
         return query.setParameter("bibId",bibliographicRecordId).getResultList();
     }
 

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -57,6 +57,19 @@ public class BibliographicBean {
         return query.setParameter("bibId",bibliographicRecordId).getResultList();
     }
 
+    /**
+     * Query bibliographic posts with the indexKey field set. This is necessary for the API, as the Jackson parser does
+     * not use the getter, thereby not using the lazy load.
+     * @param bibliographicRecordId
+     * @return All bibliographic posts matching the record id
+     */
+    public List<BibliographicEntity> getBibliographicEntitiesWithIndexKeys(String bibliographicRecordId) {
+        TypedQuery<BibliographicEntity> query = entityManager.createQuery("SELECT b FROM BibliographicEntity b " +
+                "WHERE b.bibliographicRecordId = :bibId",BibliographicEntity.class)
+                .setHint("javax.persistence.fetchgraph",entityManager.getEntityGraph("bibPostWithIndexKeys"));
+        return query.setParameter("bibId",bibliographicRecordId).getResultList();
+    }
+
     public void addBibliographicKeys(BibliographicEntity bibliographicEntity, List<String> superceds){
 
         log.info("AddBibliographicKeys called {}:{}", bibliographicEntity.agencyId, bibliographicEntity.bibliographicRecordId);

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
@@ -1,7 +1,14 @@
 package dk.dbc.search.solrdocstore;
 
 import java.io.Serializable;
-import javax.persistence.*;
+import javax.persistence.Basic;
+import javax.persistence.Convert;
+import javax.persistence.Entity;
+import javax.persistence.Id;
+import javax.persistence.IdClass;
+import javax.persistence.NamedAttributeNode;
+import javax.persistence.NamedEntityGraph;
+import javax.persistence.Table;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
@@ -1,12 +1,7 @@
 package dk.dbc.search.solrdocstore;
 
 import java.io.Serializable;
-import javax.persistence.Convert;
-import javax.persistence.Entity;
-import javax.persistence.Id;
-import javax.persistence.IdClass;
-import javax.persistence.Table;
-import javax.persistence.Basic;
+import javax.persistence.*;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -17,6 +12,7 @@ import static javax.persistence.FetchType.LAZY;
 
 @Entity
 @Table(name = "bibliographicSolrKeys")
+@NamedEntityGraph(name = "bibPostWithIndexKeys",attributeNodes = @NamedAttributeNode("indexKeys"))
 @IdClass(AgencyItemKey.class)
 public class BibliographicEntity implements Serializable {
 

--- a/service/src/main/java/dk/dbc/search/solrdocstore/FrontendAPIBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/FrontendAPIBean.java
@@ -41,7 +41,8 @@ public class FrontendAPIBean {
     public Response getBibliographicKeys(@PathParam("bibliographicRecordId") String bibliographicRecordId) {
         log.info("Requesting bibliographic record id: {}", bibliographicRecordId);
 
-        List<BibliographicEntity> res = bibliographicBean.getBibliographicEntities(bibliographicRecordId);
+        // Must be queried with index keys set, because of the Jackson parser ignores lazy loading
+        List<BibliographicEntity> res = bibliographicBean.getBibliographicEntitiesWithIndexKeys(bibliographicRecordId);
         return Response.ok(new FrontendReturnListType<>(res),MediaType.APPLICATION_JSON).build();
     }
 


### PR DESCRIPTION
Commit 2de35e38649e3ac7d4be94ff566a112d8b568c32 som implementerer lazy loading af index keys ødelagde API'en da Jackson parseren ikke benytter sig af getter, og derved aldrig får hentet index keys.

Man kan påkræve disse felter på query niveau med en JPA feature kaldet entity graphs.