### PR TITLE
Us2263 - sæt poster i kø

### DIFF
--- a/gui/app/actions/async_job.js
+++ b/gui/app/actions/async_job.js
@@ -11,6 +11,7 @@ export const JOB_STARTED = "Job started";
 export const JOB_FINISHED = "Job finished";
 export const WEBSOCKET_ERROR = "Websocket connection error";
 export const ASYNC_JOB_ERROR = "Async job had an error";
+export const ENQUEUE_JOB = "Enqueuing job";
 
 export const requestSubscribe = uuid => ({
   type: REQUEST_SUBSCRIBE,
@@ -79,4 +80,11 @@ export const websocketError = () => ({
 export const asyncJobError = exception => ({
   type: ASYNC_JOB_ERROR,
   message: exception.message
+});
+
+export const enqueueJob = (param1, param2, path) => ({
+  type: ENQUEUE_JOB,
+  param1,
+  param2,
+  path
 });

--- a/gui/app/actions/async_job.js
+++ b/gui/app/actions/async_job.js
@@ -11,7 +11,9 @@ export const JOB_STARTED = "Job started";
 export const JOB_FINISHED = "Job finished";
 export const WEBSOCKET_ERROR = "Websocket connection error";
 export const ASYNC_JOB_ERROR = "Async job had an error";
-export const ENQUEUE_JOB = "Enqueuing job";
+export const ENQUEUE_ALL_JOB = "Enqueuing all elements on queue";
+export const ASYNC_JOB_ERROR_WITH_PATTERN =
+  "Queueing elements following pattern";
 
 export const requestSubscribe = uuid => ({
   type: REQUEST_SUBSCRIBE,
@@ -82,9 +84,15 @@ export const asyncJobError = exception => ({
   message: exception.message
 });
 
-export const enqueueJob = (param1, param2, path) => ({
-  type: ENQUEUE_JOB,
-  param1,
-  param2,
-  path
+export const enqueueAllJob = (queue, includeDeleted) => ({
+  type: ENQUEUE_ALL_JOB,
+  queue,
+  includeDeleted
+});
+
+export const queueErrorsWithPattern = (path, pattern, consumer) => ({
+  type: ASYNC_JOB_ERROR_WITH_PATTERN,
+  path,
+  pattern,
+  consumer
 });

--- a/gui/app/api/index.js
+++ b/gui/app/api/index.js
@@ -66,9 +66,15 @@ export default {
   fetchFullLog(uuid) {
     return fetch(`api/log/${uuid}`).then(res => res.body);
   },
-  enqueueJob(path, param1, param2) {
+  enqueueAllJob(queue, includeDeleted) {
     return fetch(
-      `api/async-job/${path}/${param1}` + (param2 ? "/" + param2 : "")
+      `api/async-job/queue-all/${encodeURI(queue)}/${includeDeleted}`
+    );
+  },
+  errorActionWithPattern(path, pattern, consumer) {
+    return fetch(
+      `api/async-job/${path}/${encodeURI(pattern)}` +
+        (consumer ? "?consumer=" + encodeURIComponent(consumer) : "")
     );
   }
 };

--- a/gui/app/api/index.js
+++ b/gui/app/api/index.js
@@ -1,7 +1,7 @@
 export const SEARCH_BIB_ID = "searchBibId";
 export const SEARCH_REPO_ID = "searchRepoId";
 
-let parse = res => {
+const parse = res => {
   if (res.status === 200) return res.json();
   else throw new Error("Error with http status code: " + res.status);
 };
@@ -65,5 +65,10 @@ export default {
   },
   fetchFullLog(uuid) {
     return fetch(`api/log/${uuid}`).then(res => res.body);
+  },
+  enqueueJob(path, param1, param2) {
+    return fetch(
+      `api/async-job/${path}/${param1}` + (param2 ? "/" + param2 : "")
+    );
   }
 };

--- a/gui/app/components/enqueue-async-job-creator/enqueue_all.js
+++ b/gui/app/components/enqueue-async-job-creator/enqueue_all.js
@@ -49,6 +49,10 @@ class EnqueueAllAsyncJob extends React.Component {
   enqueueAll(e) {
     let { queueInput, includeDeleted } = this.state;
     this.props.enqueueAll(queueInput, includeDeleted);
+    this.setState({
+      queueInput: "",
+      includeDeleted: false
+    });
   }
 
   toggleDeleteIncluded(e) {

--- a/gui/app/components/enqueue-async-job-creator/enqueue_all.js
+++ b/gui/app/components/enqueue-async-job-creator/enqueue_all.js
@@ -1,0 +1,68 @@
+import React from "react";
+import { connect } from "react-redux";
+import { enqueueAllJob } from "../../actions/async_job";
+
+class EnqueueAllAsyncJob extends React.Component {
+  constructor(props) {
+    super(props);
+    this.state = {
+      queueInput: "",
+      includeDeleted: false
+    };
+    this.enqueueAll = this.enqueueAll.bind(this);
+    this.toggleDeleteIncluded = this.toggleDeleteIncluded.bind(this);
+  }
+
+  render() {
+    return (
+      <div className="py-3">
+        <h5>Sæt alle poster i kø</h5>
+        <input
+          placeholder="Kø navn"
+          value={this.state.queueInput}
+          onChange={e => this.setState({ queueInput: e.target.value })}
+        />
+        <span
+          className="px-4"
+          style={{ cursor: "pointer" }}
+          onClick={this.toggleDeleteIncluded}
+        >
+          Slettede poster inkluderet:
+          <input
+            type="checkbox"
+            aria-label="Checkbox for following text input"
+            checked={this.state.includeDeleted}
+            onClick={this.toggleDeleteIncluded}
+          />
+        </span>
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={this.enqueueAll}
+        >
+          Start job
+        </button>
+      </div>
+    );
+  }
+
+  enqueueAll(e) {
+    let { queueInput, includeDeleted } = this.state;
+    this.props.enqueueAll(queueInput, includeDeleted);
+  }
+
+  toggleDeleteIncluded(e) {
+    this.setState({
+      includeDeleted: !this.state.includeDeleted
+    });
+  }
+}
+
+const mapStateToProps = state => ({});
+
+const mapDispatchToProps = dispatch => ({
+  enqueueAll: (queue, includeDeleted) =>
+    dispatch(enqueueAllJob(queue, includeDeleted))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(EnqueueAllAsyncJob);

--- a/gui/app/components/enqueue-async-job-creator/enqueuer.js
+++ b/gui/app/components/enqueue-async-job-creator/enqueuer.js
@@ -1,53 +1,54 @@
 import React from "react";
 import { connect } from "react-redux";
-import { enqueueJob } from "../../actions/async_job";
+import { queueErrorsWithPattern } from "../../actions/async_job";
 
 class EnqueueAsyncJob extends React.PureComponent {
   constructor(props) {
     super(props);
     this.state = {
-      parameter1input: "",
-      parameter2input: ""
+      patternInput: "",
+      consumerInput: ""
     };
     this.enqueue = this.enqueue.bind(this);
   }
 
   render() {
-    let { name, parameter1, parameter2, path } = this.props;
+    let { name, placeholder, consumer, path } = this.props;
     return (
       <div className="p-2">
         <h5>{name}</h5>
         <input
-          placeholder={parameter1}
-          value={this.state.parameter1input}
-          onChange={e => this.setState({ parameter1input: e.target.value })}
+          placeholder={placeholder}
+          value={this.state.patternInput}
+          onChange={e => this.setState({ patternInput: e.target.value })}
         />
         <input
-          placeholder={parameter2}
-          value={this.state.parameter2input}
-          onChange={e => this.setState({ parameter2input: e.target.value })}
+          placeholder={consumer}
+          value={this.state.consumerInput}
+          onChange={e => this.setState({ consumerInput: e.target.value })}
         />
         <button
           type="button"
-          className="btn btn-primary"
+          className="btn btn-primary ml-3"
           onClick={this.enqueue}
         >
-          Kør
+          Start job
         </button>
       </div>
     );
   }
 
   enqueue() {
-    let { parameter1input, parameter2input } = this.state;
-    this.props.enqueue(parameter1input, parameter2input, this.props.path);
+    let { patternInput, consumerInput } = this.state;
+    this.props.enqueue(patternInput, consumerInput, this.props.path);
   }
 }
 
 const mapStateToProps = state => ({});
 
 const mapDispatchToProps = dispatch => ({
-  enqueue: (param1, param2, path) => dispatch(enqueueJob(param1, param2, path))
+  enqueue: (queue, consumer, path) =>
+    dispatch(queueErrorsWithPattern(path, queue, consumer))
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(EnqueueAsyncJob);

--- a/gui/app/components/enqueue-async-job-creator/enqueuer.js
+++ b/gui/app/components/enqueue-async-job-creator/enqueuer.js
@@ -1,0 +1,53 @@
+import React from "react";
+import { connect } from "react-redux";
+import { enqueueJob } from "../../actions/async_job";
+
+class EnqueueAsyncJob extends React.PureComponent {
+  constructor(props) {
+    super(props);
+    this.state = {
+      parameter1input: "",
+      parameter2input: ""
+    };
+    this.enqueue = this.enqueue.bind(this);
+  }
+
+  render() {
+    let { name, parameter1, parameter2, path } = this.props;
+    return (
+      <div className="p-2">
+        <h5>{name}</h5>
+        <input
+          placeholder={parameter1}
+          value={this.state.parameter1input}
+          onChange={e => this.setState({ parameter1input: e.target.value })}
+        />
+        <input
+          placeholder={parameter2}
+          value={this.state.parameter2input}
+          onChange={e => this.setState({ parameter2input: e.target.value })}
+        />
+        <button
+          type="button"
+          className="btn btn-primary"
+          onClick={this.enqueue}
+        >
+          Kør
+        </button>
+      </div>
+    );
+  }
+
+  enqueue() {
+    let { parameter1input, parameter2input } = this.state;
+    this.props.enqueue(parameter1input, parameter2input, this.props.path);
+  }
+}
+
+const mapStateToProps = state => ({});
+
+const mapDispatchToProps = dispatch => ({
+  enqueue: (param1, param2, path) => dispatch(enqueueJob(param1, param2, path))
+});
+
+export default connect(mapStateToProps, mapDispatchToProps)(EnqueueAsyncJob);

--- a/gui/app/components/enqueue-async-job-creator/enqueuer.js
+++ b/gui/app/components/enqueue-async-job-creator/enqueuer.js
@@ -41,6 +41,10 @@ class EnqueueAsyncJob extends React.PureComponent {
   enqueue() {
     let { patternInput, consumerInput } = this.state;
     this.props.enqueue(patternInput, consumerInput, this.props.path);
+    this.setState({
+      patternInput: "",
+      consumerInput: ""
+    });
   }
 }
 

--- a/gui/app/components/enqueue-async-job-creator/index.js
+++ b/gui/app/components/enqueue-async-job-creator/index.js
@@ -1,0 +1,35 @@
+import React from "react";
+import EnqueueAsyncJob from "./enqueuer";
+
+const EnqueueAsyncJobCreator = ({}) => {
+  return (
+    <React.Fragment>
+      <EnqueueAsyncJob
+        name="Sæt alt i kø"
+        parameter1="Queue"
+        parameter2="Include deleted (Default false)"
+        path="queue-all"
+      />
+      <EnqueueAsyncJob
+        name="Udskriv fejlede poster til log"
+        parameter1="Pattern"
+        parameter2="Consumer (Valgfri)"
+        path="list-errors"
+      />
+      <EnqueueAsyncJob
+        name="Slet fejlede poster fra fejl-tabel"
+        parameter1="Pattern"
+        parameter2="Consumer (Valgfri)"
+        path="delete-errors"
+      />
+      <EnqueueAsyncJob
+        name="Sæt fejlede poster på kø"
+        parameter1="Pattern"
+        parameter2="Consumer (Valgfri)"
+        path="requeue-errors"
+      />
+    </React.Fragment>
+  );
+};
+
+export default EnqueueAsyncJobCreator;

--- a/gui/app/components/enqueue-async-job-creator/index.js
+++ b/gui/app/components/enqueue-async-job-creator/index.js
@@ -1,31 +1,30 @@
 import React from "react";
 import EnqueueAsyncJob from "./enqueuer";
+import EnqueueAllAsyncJob from "./enqueue_all";
 
 const EnqueueAsyncJobCreator = ({}) => {
   return (
     <React.Fragment>
-      <EnqueueAsyncJob
-        name="Sæt alt i kø"
-        parameter1="Queue"
-        parameter2="Include deleted (Default false)"
-        path="queue-all"
+      <EnqueueAllAsyncJob
+        queue="Queue"
+        includeDeleted="Include deleted (Default false)"
       />
       <EnqueueAsyncJob
         name="Udskriv fejlede poster til log"
-        parameter1="Pattern"
-        parameter2="Consumer (Valgfri)"
+        placeholder="Pattern"
+        consumer="Consumer (Valgfri)"
         path="list-errors"
       />
       <EnqueueAsyncJob
         name="Slet fejlede poster fra fejl-tabel"
-        parameter1="Pattern"
-        parameter2="Consumer (Valgfri)"
+        placeholder="Pattern"
+        consumer="Consumer (Valgfri)"
         path="delete-errors"
       />
       <EnqueueAsyncJob
         name="Sæt fejlede poster på kø"
-        parameter1="Pattern"
-        parameter2="Consumer (Valgfri)"
+        placeholder="Pattern"
+        consumer="Consumer (Valgfri)"
         path="requeue-errors"
       />
     </React.Fragment>

--- a/gui/app/components/list_results.js
+++ b/gui/app/components/list_results.js
@@ -24,6 +24,10 @@ const columns = [
     Header: "Deleted",
     accessor: "deleted",
     Cell: props => "" + props.value
+  },
+  {
+    Header: "Supersede ID",
+    accessor: "supersedeId"
   }
 ];
 

--- a/gui/app/components/queue-admin-gui.js
+++ b/gui/app/components/queue-admin-gui.js
@@ -1,6 +1,7 @@
 import React from "react";
 import QueueRules from "./queue_rules";
 import AsyncJobMonitor from "./async_job_monitor";
+import EnqueueAsyncJobCreator from "./enqueue-async-job-creator";
 
 class QueueAdminGUI extends React.PureComponent {
   render() {
@@ -15,6 +16,7 @@ class QueueAdminGUI extends React.PureComponent {
           <div className="row">
             <div className="col-6">
               <QueueRules />
+              <EnqueueAsyncJobCreator />
             </div>
             <div className="col-6">
               <AsyncJobMonitor />

--- a/gui/app/components/related_holdings/manifestation.js
+++ b/gui/app/components/related_holdings/manifestation.js
@@ -38,7 +38,7 @@ class Manifestation extends React.Component {
             </div>
             <div>
               <p>
-                <b>Status:</b> {status}
+                <b>Status:</b> {status.join(", ")}
               </p>
             </div>
           </div>

--- a/gui/app/sagas/admin_queue_sagas.js
+++ b/gui/app/sagas/admin_queue_sagas.js
@@ -61,13 +61,25 @@ function* deleteQueueRules(action) {
   }
 }
 
-function* enqueueJob(action) {
+function* enqueueAllJob(action) {
   try {
     const uuid = yield call(
-      api.enqueueJob,
+      api.enqueueAllJob,
+      action.queue,
+      action.includeDeleted
+    );
+  } catch (e) {
+    yield put(asyncJobsActions.asyncJobError(e));
+  }
+}
+
+function* errorsWithPattern(action) {
+  try {
+    const uuid = yield call(
+      api.errorActionWithPattern,
       action.path,
-      action.param1,
-      action.param2
+      action.pattern,
+      action.consumer
     );
   } catch (e) {
     yield put(asyncJobsActions.asyncJobError(e));
@@ -94,8 +106,15 @@ export function* watchRequestFullLog() {
   yield takeEvery(asyncJobsActions.REQUEST_FULL_LOG, fetchFullLog);
 }
 
-export function* watchEnqueueJob() {
-  yield takeEvery(asyncJobsActions.ENQUEUE_JOB, enqueueJob);
+export function* watchEnqueueAllJob() {
+  yield takeEvery(asyncJobsActions.ENQUEUE_ALL_JOB, enqueueAllJob);
+}
+
+export function* watchErrorsWithPattern() {
+  yield takeEvery(
+    asyncJobsActions.ASYNC_JOB_ERROR_WITH_PATTERN,
+    errorsWithPattern
+  );
 }
 
 export default function* root() {
@@ -105,6 +124,7 @@ export default function* root() {
     fork(watchDeleteQueueRule),
     fork(watchRequestAsyncJobs),
     fork(watchRequestFullLog),
-    fork(watchEnqueueJob)
+    fork(watchEnqueueAllJob),
+    fork(watchErrorsWithPattern)
   ]);
 }

--- a/gui/app/sagas/admin_queue_sagas.js
+++ b/gui/app/sagas/admin_queue_sagas.js
@@ -61,6 +61,19 @@ function* deleteQueueRules(action) {
   }
 }
 
+function* enqueueJob(action) {
+  try {
+    const uuid = yield call(
+      api.enqueueJob,
+      action.path,
+      action.param1,
+      action.param2
+    );
+  } catch (e) {
+    yield put(asyncJobsActions.asyncJobError(e));
+  }
+}
+
 export function* watchPullQueueRules() {
   yield takeLatest(queueActions.PULL_QUEUE_RULES, fetchQueueRules);
 }
@@ -81,12 +94,17 @@ export function* watchRequestFullLog() {
   yield takeEvery(asyncJobsActions.REQUEST_FULL_LOG, fetchFullLog);
 }
 
+export function* watchEnqueueJob() {
+  yield takeEvery(asyncJobsActions.ENQUEUE_JOB, enqueueJob);
+}
+
 export default function* root() {
   yield all([
     fork(watchPullQueueRules),
     fork(watchCreateQueueRule),
     fork(watchDeleteQueueRule),
     fork(watchRequestAsyncJobs),
-    fork(watchRequestFullLog)
+    fork(watchRequestFullLog),
+    fork(watchEnqueueJob)
   ]);
 }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicEntity.java
@@ -2,12 +2,15 @@ package dk.dbc.search.solrdocstore;
 
 import java.io.Serializable;
 import javax.persistence.Basic;
+import javax.persistence.ColumnResult;
 import javax.persistence.Convert;
 import javax.persistence.Entity;
+import javax.persistence.EntityResult;
 import javax.persistence.Id;
 import javax.persistence.IdClass;
 import javax.persistence.NamedAttributeNode;
 import javax.persistence.NamedEntityGraph;
+import javax.persistence.SqlResultSetMapping;
 import javax.persistence.Table;
 import java.util.Arrays;
 import java.util.List;
@@ -21,6 +24,9 @@ import static javax.persistence.FetchType.LAZY;
 @Entity
 @Table(name = "bibliographicSolrKeys")
 @NamedEntityGraph(name = "bibPostWithIndexKeys",attributeNodes = @NamedAttributeNode("indexKeys"))
+@SqlResultSetMapping(name="BibliographicEntityWithSupersedeId",entities = {
+        @EntityResult(entityClass = BibliographicEntity.class),
+},columns = {@ColumnResult(name="supersede_id")})
 @IdClass(AgencyItemKey.class)
 public class BibliographicEntity implements Serializable {
     public static final List<String> sortableColumns = Arrays.asList("agencyId","bibliographicRecordId","producerVersion","deleted","trackingId");

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicFrontendEntity.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicFrontendEntity.java
@@ -1,0 +1,18 @@
+package dk.dbc.search.solrdocstore;
+
+public class BibliographicFrontendEntity extends BibliographicEntity {
+    private String supersedeId;
+
+    BibliographicFrontendEntity(BibliographicEntity b,String liveId){
+        super(b.getAgencyId(),b.getBibliographicRecordId(),b.getWork(),b.getUnit(),b.getProducerVersion(),b.isDeleted(),b.getIndexKeys(),b.getTrackingId());
+        supersedeId = liveId;
+    }
+
+    public String getSupersedeId(){
+        return supersedeId;
+    }
+
+    public void setSupersedeId(String supersedeId){
+        this.supersedeId = supersedeId;
+    }
+}

--- a/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
@@ -26,10 +26,7 @@ import java.util.stream.Collectors;
 import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.validation.constraints.NotNull;
-import javax.ws.rs.GET;
-import javax.ws.rs.Path;
-import javax.ws.rs.PathParam;
-import javax.ws.rs.Produces;
+import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.annotation.XmlRootElement;
@@ -107,8 +104,9 @@ public class AsyncJobControl {
      * */
     @GET
     @Produces({MediaType.TEXT_PLAIN})
-    @Path("list-errors/{pattern}{consumer : (/consumer)?}")
-    public Response listErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+    @Path("list-errors/{pattern}")
+    public Response listErrors(@PathParam("pattern") String pattern,@QueryParam("consumer") String consumer){
+        log.info("Pattern: {} - Consumer: {}",pattern,consumer);
         String id = queueAsyncJob.runQueueErrorListJobs(consumer,pattern);
         return Response.ok(id).build();
     }
@@ -122,8 +120,8 @@ public class AsyncJobControl {
      * */
     @GET
     @Produces({MediaType.TEXT_PLAIN})
-    @Path("delete-errors/{pattern}{consumer : (/consumer)?}")
-    public Response deleteErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+    @Path("delete-errors/{pattern}")
+    public Response deleteErrors(@PathParam("pattern") String pattern,@QueryParam("consumer") String consumer){
         String id = queueAsyncJob.runQueueErrorDeleteJobs(consumer,pattern);
         return Response.ok(id).build();
     }
@@ -137,8 +135,8 @@ public class AsyncJobControl {
      * */
     @GET
     @Produces({MediaType.TEXT_PLAIN})
-    @Path("requeue-errors/{pattern}{consumer : (/consumer)?}")
-    public Response requeueErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+    @Path("requeue-errors/{pattern}")
+    public Response requeueErrors(@PathParam("pattern") String pattern,@QueryParam("consumer") String consumer){
         String id = queueAsyncJob.runQueueErrorRequeueJobs(consumer,pattern);
         return Response.ok(id).build();
     }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
@@ -33,6 +33,9 @@ import javax.ws.rs.Produces;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 import javax.xml.bind.annotation.XmlRootElement;
+
+import dk.dbc.search.solrdocstore.QueueAsyncJob;
+import dk.dbc.search.solrdocstore.queue.QueueJob;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -48,6 +51,9 @@ public class AsyncJobControl {
 
     @Inject
     AsyncJobRunner runner;
+
+    @Inject
+    QueueAsyncJob queueAsyncJob;
 
     @GET
     @Produces({MediaType.TEXT_PLAIN})
@@ -74,6 +80,66 @@ public class AsyncJobControl {
             }
 
         });
+        return Response.ok(id).build();
+    }
+
+    /**
+     * Run the "queue everything" async job
+     *
+     * @param queue      Name of consumer
+     * @param deletedTo even the deleted
+     * @return HTTP response with the UUID of the job
+     * */
+    @GET
+    @Produces({MediaType.TEXT_PLAIN})
+    @Path("queue-all/{queue}/{deletedTo}")
+    public Response queueAll(@PathParam("queue") String queue,@PathParam("deletedTo") boolean deletedTo){
+        String id = queueAsyncJob.runQueueAllManifestationsFor(queue,deletedTo);
+        return Response.ok(id).build();
+    }
+
+    /**
+     * Run the "list errors" async job
+     *
+     * @param consumer consumer that failed (can be null or empty string)
+     * @param pattern  diag pattern with * and ?
+     * @return HTTP response with the UUID of the job
+     * */
+    @GET
+    @Produces({MediaType.TEXT_PLAIN})
+    @Path("list-errors/{pattern}{consumer : (/consumer)?}")
+    public Response listErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+        String id = queueAsyncJob.runQueueErrorListJobs(consumer,pattern);
+        return Response.ok(id).build();
+    }
+
+    /**
+     * Run the "delete errors" async job
+     *
+     * @param consumer consumer that failed (can be null or empty string)
+     * @param pattern  diag pattern with * and ?
+     * @return HTTP response with the UUID of the job
+     * */
+    @GET
+    @Produces({MediaType.TEXT_PLAIN})
+    @Path("delete-errors/{pattern}{consumer : (/consumer)?}")
+    public Response deleteErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+        String id = queueAsyncJob.runQueueErrorDeleteJobs(consumer,pattern);
+        return Response.ok(id).build();
+    }
+
+    /**
+     * Run the "requeue errors" async job
+     *
+     * @param consumer consumer that failed (can be null or empty string)
+     * @param pattern  diag pattern with * and ?
+     * @return HTTP response with the UUID of the job
+     * */
+    @GET
+    @Produces({MediaType.TEXT_PLAIN})
+    @Path("requeue-errors/{pattern}{consumer : (/consumer)?}")
+    public Response requeueErrors(@PathParam("pattern") String pattern,@PathParam("consumer") String consumer){
+        String id = queueAsyncJob.runQueueErrorRequeueJobs(consumer,pattern);
         return Response.ok(id).build();
     }
 

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BiliographicRecordAPIBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BiliographicRecordAPIBeanIT.java
@@ -85,11 +85,12 @@ public class BiliographicRecordAPIBeanIT extends JpaSolrDocStoreIntegrationTeste
 
     @Test
     public void testGetBibliographicRecord(){
-       Response result = bean.getBibliographicRecord("page-order", "103862");
-       BibliographicEntity res = (BibliographicEntity)result.getEntity();
+       Response result = bean.getBibliographicRecord("page-order", 103862);
+       BibliographicFrontendEntity res = (BibliographicFrontendEntity)result.getEntity();
        Map<String,List<String>> map = new HashMap<>();
        map.put("rec.repositoryId", Collections.singletonList("p-o"));
-       Assert.assertEquals(res,new BibliographicEntity(103862,"page-order","work:2","unit:6","producer:3",false,map,"track:8"));
+       BibliographicEntity b = new BibliographicEntity(103862,"page-order","work:2","unit:6","producer:3",false,map,"track:8");
+       Assert.assertEquals(res,new BibliographicFrontendEntity(b,"0639423"));
     }
 
     @Test

--- a/service/src/test/resources/frontendIT.sql
+++ b/service/src/test/resources/frontendIT.sql
@@ -15,3 +15,5 @@ VALUES (706244, 'page-order', TRUE, '{"rec.repositoryId": ["p-o"]}' :: JSONB, 'p
 INSERT INTO bibliographicSolrKeys (AGENCYID, BIBLIOGRAPHICRECORDID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
 VALUES (808077, 'page-order', FALSE, '{"rec.repositoryId": ["p-o"]}' :: JSONB, 'producer:8', 'track:1', 'unit:7', 'work:7');
 
+INSERT INTO bibliographictobibliographic (DEADBIBLIOGRAPHICRECORDID,LIVEBIBLIOGRAPHICRECORDID)
+VALUES ('page-order','0639423');


### PR DESCRIPTION
To nye features:
 - Man kan nu sætte de eksisterende asynkrone jobs i gang via GUI:
   - Lig alle elementer på kø
   - List elementer på fejlkø
   - Slet elementer på fejl kø som følger pattern
   - Lig elementer på fejl kø på kø som følger pattern
 - supersede ID bliver nu vist i GUI når man kigger på bibliografiske poster