### PR TITLE
Allow for saving all documents posted to SolR as JSON

### DIFF
--- a/solr-updater/src/main/docker/Dockerfile
+++ b/solr-updater/src/main/docker/Dockerfile
@@ -19,7 +19,8 @@ LABEL SOLR_URL="zk or http url of solr-collection (required)" \
       OPEN_AGENCY_URL="URL for OpenAgency service (required)" \
       OPEN_AGENCY_AGE="Caching of successful openagency call (default: 4h)" \
       OPEN_AGENCY_FAILURE_AGE="Caching of unsuccessful result (default: 5m)"\
-      OPEN_AGENCY_TIMEOUT="Open agency timeout (default: 1m)"
+      OPEN_AGENCY_TIMEOUT="Open agency timeout (default: 1m)" \
+      JSON_STASH="Path for storing posted documents as JSON for generating test data (optional)"
 
 ADD config.d/* config.d
 ADD *.war wars/

--- a/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/DocStasher.java
+++ b/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/DocStasher.java
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2019 DBC A/S (http://dbc.dk/)
+ *
+ * This is part of solr-doc-store-updater
+ *
+ * solr-doc-store-updater is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Affero General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * solr-doc-store-updater is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU Affero General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package dk.dbc.search.solrdocstore.updater;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+import java.time.Instant;
+import javax.annotation.PostConstruct;
+import javax.ejb.Stateless;
+import org.apache.solr.common.SolrInputDocument;
+import org.slf4j.LoggerFactory;
+
+/**
+ *
+ * @author Morten Bøgeskov (mb@dbc.dk)
+ */
+@Stateless
+public class DocStasher {
+
+    private static final org.slf4j.Logger log = LoggerFactory.getLogger(DocStasher.class);
+
+    private static final ObjectMapper O = new ObjectMapper();
+
+    private Path path;
+
+    @PostConstruct
+    public void init() {
+        String pathBase = System.getenv("JSON_STASH");
+        if (pathBase == null) {
+            path = null;
+        } else {
+            path = new File(pathBase).toPath();
+            log.info("Using base: {} for storing json files");
+        }
+    }
+
+    public void store(String pid, SolrInputDocument doc) {
+        if(path == null)
+            return;
+        try {
+            File file = path.resolve(pid + "_" + Instant.now().toString()).toFile();
+            ObjectNode obj = O.createObjectNode();
+            docIntoObject(doc, obj);
+            log.info("Writing to file: {}", file);
+            O.writeValue(file, obj);
+        } catch (IOException ex) {
+            log.error("Error writeing JSON doc: {}", ex.getMessage());
+            log.debug("Error writeing JSON doc: ", ex);
+        }
+    }
+
+    private void docIntoObject(SolrInputDocument doc, ObjectNode obj) {
+        doc.getFieldNames().forEach(field -> {
+            ArrayNode values = obj.putArray(field);
+            doc.getFieldValues(field).stream()
+                    .map(String::valueOf)
+                    .forEach(values::add);
+        });
+        if (doc.hasChildDocuments()) {
+            ArrayNode children = obj.putArray("_childDocuments_");
+            doc.getChildDocuments().forEach(d -> docIntoObject(d, children.addObject()));
+        }
+    }
+
+}

--- a/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/Worker.java
+++ b/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/Worker.java
@@ -45,6 +45,9 @@ public class Worker {
     DocProducer docProducer;
 
     @Inject
+    DocStasher docStasher;
+
+    @Inject
     MetricRegistry metrics;
 
     @Resource(lookup = Config.DATABASE)
@@ -94,6 +97,14 @@ public class Worker {
                     docProducer.deleteSolrDocuments(bibliographicShardId, ids, job.getCommitwithin());
 
                     docProducer.deploy(solrDocument, job.getCommitwithin());
+                    StringBuilder pid = new StringBuilder();
+                    pid.append(job.getAgencyId())
+                            .append('-')
+                            .append(job.getClassifier())
+                            .append(':')
+                            .append(job.getBibliographicRecordId());
+
+                    docStasher.store(pid.toString(), solrDocument);
                 } catch (IOException ex) {
                     throw new NonFatalQueueError(ex);
                 } catch (SolrServerException ex) {


### PR DESCRIPTION
Option to save generated SolR documents as JSON, to generate test data for other projects integration tests.