### PR TITLE
SE-2557 delay when deleting bibliographic entities

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/AgencyClassifierItemKey.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/AgencyClassifierItemKey.java
@@ -2,6 +2,7 @@ package dk.dbc.search.solrdocstore;
 
 import dk.dbc.search.solrdocstore.queue.QueueJob;
 import javax.persistence.Embeddable;
+import javax.persistence.Transient;
 import java.io.Serializable;
 import java.util.Objects;
 
@@ -13,6 +14,8 @@ public class AgencyClassifierItemKey implements Serializable {
     private int agencyId;
     private String classifier;
     private String bibliographicRecordId;
+    @Transient
+    private boolean deleteMarked;
 
     public AgencyClassifierItemKey() {
     }
@@ -21,6 +24,14 @@ public class AgencyClassifierItemKey implements Serializable {
         this.agencyId = agencyId;
         this.classifier = classifier;
         this.bibliographicRecordId = bibliographicRecordId;
+        this.deleteMarked = false;
+    }
+
+    public AgencyClassifierItemKey(int agencyId, String classifier, String bibliographicRecordId, boolean deleteMarked) {
+        this.agencyId = agencyId;
+        this.classifier = classifier;
+        this.bibliographicRecordId = bibliographicRecordId;
+        this.deleteMarked = deleteMarked;
     }
 
     @Override
@@ -91,5 +102,13 @@ public class AgencyClassifierItemKey implements Serializable {
 
     public QueueJob toQueueJob(Integer commitWithin) {
         return new QueueJob(agencyId, classifier, bibliographicRecordId, commitWithin);
+    }
+
+    public boolean isDeleteMarked() {
+        return deleteMarked;
+    }
+
+    public void setDeleteMarked(boolean deleteMarked) {
+        this.deleteMarked = deleteMarked;
     }
 }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/AgencyClassifierItemKey.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/AgencyClassifierItemKey.java
@@ -14,6 +14,7 @@ public class AgencyClassifierItemKey implements Serializable {
     private int agencyId;
     private String classifier;
     private String bibliographicRecordId;
+    // Property used to communicate to enqueuer if bib entity is being deleted
     @Transient
     private boolean deleteMarked;
 

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -45,9 +45,6 @@ public class BibliographicBean {
     OpenAgencyBean openAgency;
 
     @Inject
-    EnqueueSupplierBean queue;
-
-    @Inject
     HoldingsToBibliographicBean h2bBean;
 
     @Inject
@@ -146,7 +143,7 @@ public class BibliographicBean {
             }
         }
 
-        enqueueAdapter.enqueueAll(queue, affectedKeys, commitWithin);
+        enqueueAdapter.enqueueAll(affectedKeys, commitWithin);
     }
 
     /*

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -110,7 +110,6 @@ public class BibliographicBean {
             log.info("AddBibliographicKeys - Updating existing entity");
             // If we delete or re-create, related holdings must be moved appropriately
             if (bibliographicEntity.isDeleted() != dbbe.isDeleted()) {
-                // TODO mark as delete
                 AgencyClassifierItemKey key = bibliographicEntity.asAgencyClassifierItemKey();
                 key.setDeleteMarked(true);
                 affectedKeys.add(key);

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -111,8 +111,13 @@ public class BibliographicBean {
             // If we delete or re-create, related holdings must be moved appropriately
             if (bibliographicEntity.isDeleted() != dbbe.isDeleted()) {
                 AgencyClassifierItemKey key = bibliographicEntity.asAgencyClassifierItemKey();
-                key.setDeleteMarked(true);
-                affectedKeys.add(key);
+                // If incoming bib entity is deleted, we mark it as delete so the enqueue adapter
+                // will delay the queue job, to prevent race conditions with updates to this same
+                // bib entity
+                if (bibliographicEntity.isDeleted()) {
+                    key.setDeleteMarked(true);
+                    affectedKeys.add(key);
+                }
                 log.info("AddBibliographicKeys - Delete or recreate, going from {} -> {}", dbbe.isDeleted(), bibliographicEntity.isDeleted());
                 // We must flush since the tryAttach looks at the deleted field
                 entityManager.merge(bibliographicEntity.asBibliographicEntity());

--- a/service/src/main/java/dk/dbc/search/solrdocstore/Config.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/Config.java
@@ -39,6 +39,7 @@ public class Config {
         systemName = getValue(props, "systemName", "SYSTEM_NAME", "System navn ikke konfigureret", null);
         allowNonEmptySchema = getValue(props, "allowNonEmptySchema", "ALLOW_NON_EMPTY_SCHEMA", "false", null, Boolean::parseBoolean);
         openAgencyValidateTime = getValue(props, "openAgencyValidateTime", "OPEN_AGENCY_VALIDATE_TIME", "04:23:17", null, Config::validateTime);
+        // Number of milliseconds to delay bib entities that are being deleted
         deleteMarkedDelay = getValue(props, "deleteMarkedDelay", "DELETE_MARKED_DELAY", "200000", null, Long::parseUnsignedLong);
     }
 

--- a/service/src/main/java/dk/dbc/search/solrdocstore/Config.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/Config.java
@@ -28,6 +28,7 @@ public class Config {
     private String systemName;
     private Boolean allowNonEmptySchema;
     private int[] openAgencyValidateTime;
+    private long deleteMarkedDelay;
 
     @PostConstruct
     public void loadProperties() {
@@ -38,6 +39,7 @@ public class Config {
         systemName = getValue(props, "systemName", "SYSTEM_NAME", "System navn ikke konfigureret", null);
         allowNonEmptySchema = getValue(props, "allowNonEmptySchema", "ALLOW_NON_EMPTY_SCHEMA", "false", null, Boolean::parseBoolean);
         openAgencyValidateTime = getValue(props, "openAgencyValidateTime", "OPEN_AGENCY_VALIDATE_TIME", "04:23:17", null, Config::validateTime);
+        deleteMarkedDelay = getValue(props, "deleteMarkedDelay", "DELETE_MARKED_DELAY", "200000", null, Long::parseUnsignedLong);
     }
 
     public String getOaURL() {
@@ -58,6 +60,10 @@ public class Config {
 
     public int[] getOpenAgencyValidateTime() {
         return openAgencyValidateTime;
+    }
+
+    public long getDeleteMarkedDelay() {
+        return deleteMarkedDelay;
     }
 
     private static String getValue(Properties props, String propertyName, String envName, String defaultValue, String error) {

--- a/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueAdapter.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueAdapter.java
@@ -4,13 +4,13 @@ import java.sql.SQLException;
 import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
-import javax.ejb.Singleton;
+import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Singleton
+@Stateless
 public class EnqueueAdapter {
 
     @Inject

--- a/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueAdapter.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueAdapter.java
@@ -5,22 +5,23 @@ import java.util.HashSet;
 import java.util.Optional;
 import java.util.Set;
 import javax.ejb.Singleton;
-import javax.ejb.Stateless;
 import javax.inject.Inject;
 import javax.persistence.PersistenceException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Stateless
 @Singleton
 public class EnqueueAdapter {
 
     @Inject
     Config config;
 
+    @Inject
+    EnqueueSupplierBean queue;
+
     private static Logger log = LoggerFactory.getLogger(EnqueueAdapter.class);
 
-    public void enqueueAll(EnqueueSupplierBean queue, Set<AgencyClassifierItemKey> agencyItemKeys, Optional<Integer> commitWithin) {
+    public void enqueueAll(Set<AgencyClassifierItemKey> agencyItemKeys, Optional<Integer> commitWithin) {
         for (AgencyClassifierItemKey k : agencyItemKeys) {
             try {
                 // If delete marked, set postponed option

--- a/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueService.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueService.java
@@ -24,6 +24,7 @@ import dk.dbc.search.solrdocstore.queue.QueueJob;
 import java.sql.Connection;
 import java.sql.SQLException;
 import java.util.Collection;
+import java.util.Optional;
 import java.util.function.BiFunction;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -48,14 +49,19 @@ public class EnqueueService<T> {
     }
 
     public void enqueue(T t) throws SQLException {
-        enqueue(t, null);
+        enqueue(t, null, Optional.empty());
     }
 
-    public void enqueue(T t, Integer commitWithin) throws SQLException {
+    // TODO postponed option from enqueue
+    public void enqueue(T t, Integer commitWithin, Optional<Long> postponed) throws SQLException {
         QueueJob job = jobCreator.apply(t, commitWithin);
         for (String queueName : queueNames) {
             log.trace("enqueue {} to: {}", job, queueName);
-            queueSupplier.enqueue(queueName, job);
+            if (postponed.isPresent()) {
+                queueSupplier.enqueue(queueName, job, postponed.get());
+            } else {
+                queueSupplier.enqueue(queueName, job);
+            }
         }
     }
 }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueService.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/EnqueueService.java
@@ -52,7 +52,6 @@ public class EnqueueService<T> {
         enqueue(t, null, Optional.empty());
     }
 
-    // TODO postponed option from enqueue
     public void enqueue(T t, Integer commitWithin, Optional<Long> postponed) throws SQLException {
         QueueJob job = jobCreator.apply(t, commitWithin);
         for (String queueName : queueNames) {

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsItemBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsItemBean.java
@@ -39,6 +39,9 @@ public class HoldingsItemBean {
     @Inject
     EnqueueSupplierBean queue;
 
+    @Inject
+    EnqueueAdapter enqueueAdapter;
+
     @PersistenceContext(unitName = "solrDocumentStore_PU")
     EntityManager entityManager;
 
@@ -62,7 +65,7 @@ public class HoldingsItemBean {
         entityManager.merge(hi);
         Set<AgencyClassifierItemKey> affectedKeys =
                 h2bBean.tryToAttachToBibliographicRecord(hi.getAgencyId(), hi.getBibliographicRecordId());
-        EnqueueAdapter.enqueueAll(queue, affectedKeys, commitWithin);
+        enqueueAdapter.enqueueAll(queue, affectedKeys, commitWithin);
     }
 
     private Query generateRelatedHoldingsQuery(String bibliographicRecordId, int bibliographicAgencyId) {

--- a/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsItemBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/HoldingsItemBean.java
@@ -37,9 +37,6 @@ public class HoldingsItemBean {
     HoldingsToBibliographicBean h2bBean;
 
     @Inject
-    EnqueueSupplierBean queue;
-
-    @Inject
     EnqueueAdapter enqueueAdapter;
 
     @PersistenceContext(unitName = "solrDocumentStore_PU")
@@ -65,7 +62,7 @@ public class HoldingsItemBean {
         entityManager.merge(hi);
         Set<AgencyClassifierItemKey> affectedKeys =
                 h2bBean.tryToAttachToBibliographicRecord(hi.getAgencyId(), hi.getBibliographicRecordId());
-        enqueueAdapter.enqueueAll(queue, affectedKeys, commitWithin);
+        enqueueAdapter.enqueueAll(affectedKeys, commitWithin);
     }
 
     private Query generateRelatedHoldingsQuery(String bibliographicRecordId, int bibliographicAgencyId) {

--- a/service/src/main/java/dk/dbc/search/solrdocstore/ResourceBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/ResourceBean.java
@@ -42,6 +42,9 @@ public class ResourceBean {
     @Inject
     EnqueueSupplierBean queue;
 
+    @Inject
+    EnqueueAdapter enqueueAdapter;
+
     @PersistenceContext(unitName = "solrDocumentStore_PU")
     EntityManager entityManager;
 
@@ -76,7 +79,7 @@ public class ResourceBean {
             }
             Set<AgencyClassifierItemKey> keySet = bibliographicEntities.stream()
                     .map(BibliographicEntity::asAgencyClassifierItemKey).collect(Collectors.toSet());
-            EnqueueAdapter.enqueueAll(queue, keySet, Optional.empty());
+            enqueueAdapter.enqueueAll(queue, keySet, Optional.empty());
             return Response.ok().entity(new StatusBean.Resp()).build();
         }
     }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/ResourceBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/ResourceBean.java
@@ -40,9 +40,6 @@ public class ResourceBean {
     OpenAgencyBean openAgency;
 
     @Inject
-    EnqueueSupplierBean queue;
-
-    @Inject
     EnqueueAdapter enqueueAdapter;
 
     @PersistenceContext(unitName = "solrDocumentStore_PU")
@@ -79,7 +76,7 @@ public class ResourceBean {
             }
             Set<AgencyClassifierItemKey> keySet = bibliographicEntities.stream()
                     .map(BibliographicEntity::asAgencyClassifierItemKey).collect(Collectors.toSet());
-            enqueueAdapter.enqueueAll(queue, keySet, Optional.empty());
+            enqueueAdapter.enqueueAll(keySet, Optional.empty());
             return Response.ok().entity(new StatusBean.Resp()).build();
         }
     }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BeanFactoryUtil.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BeanFactoryUtil.java
@@ -21,7 +21,6 @@ public class BeanFactoryUtil {
         OpenAgencyBean openAgency = createOpenAgencyBean();
         bean.entityManager = em;
         bean.openAgency = openAgency;
-        bean.queue = createEnqueueSupplier(env);
         bean.h2bBean = createHoldingsToBibliographicBean(env);
         bean.brBean = createBibliographicRetrieveBean(env);
         bean.enqueueAdapter = createEnqueueAdapter(env);
@@ -40,7 +39,6 @@ public class BeanFactoryUtil {
         HoldingsItemBean bean = new HoldingsItemBean();
         bean.entityManager = env.getEntityManager();
         bean.h2bBean = createHoldingsToBibliographicBean(env);
-        bean.queue = createEnqueueSupplier(env);
         bean.enqueueAdapter = createEnqueueAdapter(env);
         return bean;
     }
@@ -94,6 +92,7 @@ public class BeanFactoryUtil {
                 return 200000;
             }
         };
+        enqueueAdapter.queue = createEnqueueSupplier(env);
         return enqueueAdapter;
     }
 
@@ -164,7 +163,6 @@ public class BeanFactoryUtil {
         HoldingsItemBean bean = new HoldingsItemBean();
         bean.entityManager = em;
         bean.h2bBean = h2bBean;
-        bean.queue = queue;
         return bean;
     }
 
@@ -172,7 +170,6 @@ public class BeanFactoryUtil {
         ResourceBean bean = new ResourceBean();
         OpenAgencyBean openAgency = createOpenAgencyBean();
         bean.entityManager = env.getEntityManager();
-        bean.queue = createEnqueueSupplier(env);
         bean.openAgency = openAgency;
         bean.enqueueAdapter = createEnqueueAdapter(env);
         return bean;

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BeanFactoryUtil.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BeanFactoryUtil.java
@@ -24,6 +24,7 @@ public class BeanFactoryUtil {
         bean.queue = createEnqueueSupplier(env);
         bean.h2bBean = createHoldingsToBibliographicBean(env);
         bean.brBean = createBibliographicRetrieveBean(env);
+        bean.enqueueAdapter = createEnqueueAdapter(env);
         return bean;
     }
 
@@ -40,6 +41,7 @@ public class BeanFactoryUtil {
         bean.entityManager = env.getEntityManager();
         bean.h2bBean = createHoldingsToBibliographicBean(env);
         bean.queue = createEnqueueSupplier(env);
+        bean.enqueueAdapter = createEnqueueAdapter(env);
         return bean;
     }
 
@@ -82,6 +84,17 @@ public class BeanFactoryUtil {
         EntityManager entityManager = env.getEntityManager();
         bean.entityManager = entityManager;
         return bean;
+    }
+
+    public static EnqueueAdapter createEnqueueAdapter(JpaTestEnvironment env) {
+        EnqueueAdapter enqueueAdapter = new EnqueueAdapter();
+        enqueueAdapter.config = new Config() {
+            @Override
+            public long getDeleteMarkedDelay() {
+                return 200000;
+            }
+        };
+        return enqueueAdapter;
     }
 
     public static OpenAgencyBean createOpenAgencyBean() {
@@ -161,6 +174,7 @@ public class BeanFactoryUtil {
         bean.entityManager = env.getEntityManager();
         bean.queue = createEnqueueSupplier(env);
         bean.openAgency = openAgency;
+        bean.enqueueAdapter = createEnqueueAdapter(env);
         return bean;
     }
 }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -150,7 +150,6 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
                 .run(() -> bean.addBibliographicKeys(null, updatedB)
                 );
         assertThat(r.getStatus(), is(200));
-        // TODO
         try (Connection conn = env().getDatasource().getConnection();
              Statement statement = conn.createStatement();
              ResultSet resultSet = statement.executeQuery("SELECT dequeueafter FROM queue")) {

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -9,10 +9,9 @@ import org.junit.Test;
 import javax.persistence.EntityManager;
 import javax.ws.rs.core.Response;
 import java.net.URISyntaxException;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
+import java.sql.*;
+import java.util.*;
+import java.util.Date;
 import java.util.function.Consumer;
 
 import static dk.dbc.search.solrdocstore.BeanFactoryUtil.*;
@@ -140,6 +139,27 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
                 .run(() -> bean.addBibliographicKeys(null, updatedD)
                 );
         assertThat(rd.getStatus(), is(200));
+    }
+
+    @Test
+    public void updateExistingBibliographicPostToDeletedIsDelayed() throws JSONBException, SQLException {
+        BibliographicEntity b = new BibliographicEntity(600100, "clazzifier", "delay", "id#2", "work:delay", "unit:delay", "prod:delay", true, new HashMap<>(), "track:delay");
+        String updatedB = jsonbContext.marshall(b);
+
+        Response r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(null, updatedB)
+                );
+        assertThat(r.getStatus(), is(200));
+        // TODO
+        try (Connection conn = env().getDatasource().getConnection();
+             Statement statement = conn.createStatement();
+             ResultSet resultSet = statement.executeQuery("SELECT dequeueafter FROM queue")) {
+            while (resultSet.next()) {
+                Timestamp dequeueAfter = resultSet.getTimestamp(1);
+                Date now = new Date();
+                assertThat(dequeueAfter.after(now), is(true));
+            }
+        }
     }
 
     /**

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -150,12 +150,14 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
                 .run(() -> bean.addBibliographicKeys(null, updatedB)
                 );
         assertThat(r.getStatus(), is(200));
+        // Record what time the bib entity was queued
+        Date now = new Date();
         try (Connection conn = env().getDatasource().getConnection();
              Statement statement = conn.createStatement();
              ResultSet resultSet = statement.executeQuery("SELECT dequeueafter FROM queue")) {
             while (resultSet.next()) {
                 Timestamp dequeueAfter = resultSet.getTimestamp(1);
-                Date now = new Date();
+                // Assert delay
                 assertThat(dequeueAfter.after(now), is(true));
             }
         }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/EnqueueSupplierBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/EnqueueSupplierBeanIT.java
@@ -76,9 +76,9 @@ public class EnqueueSupplierBeanIT extends JpaSolrDocStoreIntegrationTester {
                 System.out.println("* no commitWithin");
                 enqeueService.enqueue(new AgencyClassifierItemKey(870970, "clazzifier", "12345678"));
                 System.out.println("* commitWithin");
-                enqeueService.enqueue(new AgencyClassifierItemKey(870970, "clazzifier", "87654321"), 100);
+                enqeueService.enqueue(new AgencyClassifierItemKey(870970, "clazzifier", "87654321"), 100, Optional.empty());
                 System.out.println("* null commitWithin");
-                enqeueService.enqueue(new AgencyClassifierItemKey(870970, "clazzifier", "abc"), null);
+                enqeueService.enqueue(new AgencyClassifierItemKey(870970, "clazzifier", "abc"), null, Optional.empty());
                 System.out.println("* queueing done");
             } catch (SQLException ex) {
                 log.error("Exception: " + ex.getMessage());

--- a/service/src/test/resources/bibliographicUpdate.sql
+++ b/service/src/test/resources/bibliographicUpdate.sql
@@ -74,6 +74,9 @@ VALUES (300200, 'new', FALSE, '[]' :: JSONB, 'revision', 'track');
 INSERT INTO holdingsitemssolrkeys (AGENCYID, BIBLIOGRAPHICRECORDID, HASLIVEHOLDINGS, INDEXKEYS, PRODUCERVERSION, TRACKINGID)
 VALUES (800000, 'new', FALSE, '[]' :: JSONB, 'revision', 'track');
 
+-- Values for testing proper delay on update
+INSERT INTO bibliographicSolrKeys (AGENCYID, CLASSIFIER, BIBLIOGRAPHICRECORDID, REPOSITORYID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)
+VALUES (600100, 'clazzifier', 'delay', 'id#0', FALSE, '{}' :: JSONB, '5544', 'track', 'unit:3', 'work:3');
 
 -- Values for testing proper holdings update
 INSERT INTO bibliographicSolrKeys (AGENCYID, CLASSIFIER, BIBLIOGRAPHICRECORDID, REPOSITORYID, DELETED, INDEXKEYS, PRODUCERVERSION, TRACKINGID, UNIT, WORK)


### PR DESCRIPTION
Delay bibliographic entities that are being deleted by using the postpone options in the PreparedQueueSupplier.

Delay can be configured by an environment variable, is a default value of 200000 ms okay?