### PR TITLE
skipQueue=true allows for not queueing records with no structural change

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -57,6 +57,25 @@ public class BibliographicBean {
     @PersistenceContext(unitName = "solrDocumentStore_PU")
     EntityManager entityManager;
 
+    /**
+     * Add bibliographic SolR keys and reorganize related holdings
+     * <p>
+     * It enqueues all affected documents, fx. if a holding has been moved from
+     * another bibliographic record to this.
+     * <p>
+     * If skipQueue is set to true, then don't add the record to the queue,
+     * unless, holdings has been moved (ie. if only this record is to be queued
+     * then don't queue it). This is usefull if you have added a new fiels to
+     * the SolR keys, that the current systems doesn't know about. So that from
+     * their perspective nothing has changed. This is to avoid unnecessary load
+     * on the downstream systems.
+     *
+     * @param skipQueue   Don't queue unless necessary
+     * @param jsonContent The json request (see
+     *                    {@link BibliographicEntityRequest})
+     * @return Json with ok: true/false
+     * @throws Exception If database is unavailable or the JSON cannot be created
+     */
     @POST
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})

--- a/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/asyncjob/AsyncJobControl.java
@@ -29,7 +29,7 @@ import javax.validation.constraints.NotNull;
 import javax.ws.rs.*;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
-import javax.xml.bind.annotation.XmlRootElement;
+//import javax.xml.bind.annotation.XmlRootElement;
 
 import dk.dbc.search.solrdocstore.QueueAsyncJob;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
@@ -260,7 +260,7 @@ public class AsyncJobControl {
         return Response.ok().entity(new StatusResponse(job, id)).build();
     }
 
-    @XmlRootElement
+//    @XmlRootElement
     @SuppressFBWarnings("URF_UNREAD_PUBLIC_OR_PROTECTED_FIELD")
     public static class StatusResponse {
 

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -42,7 +42,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String b870970 = makeBibliographicRequestJson(870970);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b870970)
+                .run(() -> bean.addBibliographicKeys(false, b870970)
                 );
 
         assertThat(r.getStatus(), is(200));
@@ -59,7 +59,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String b700000 = makeBibliographicRequestJson(700000);
 
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b700000)
+                .run(() -> bean.addBibliographicKeys(false, b700000)
                 );
 
         assertThat(r.getStatus(), is(200));
@@ -76,7 +76,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String b300100 = makeBibliographicRequestJson(300100);
 
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b300100)
+                .run(() -> bean.addBibliographicKeys(false, b300100)
                 );
         assertThat(r.getStatus(), is(200));
 
@@ -91,7 +91,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String b300000 = makeBibliographicRequestJson(300000);
 
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b300000)
+                .run(() -> bean.addBibliographicKeys(false, b300000)
                 );
         assertThat(r.getStatus(), is(200));
 
@@ -110,7 +110,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String updatedB = jsonbContext.marshall(b);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, updatedB)
+                .run(() -> bean.addBibliographicKeys(false, updatedB)
                 );
         assertThat(r.getStatus(), is(200));
 
@@ -132,7 +132,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String updatedB = jsonbContext.marshall(b);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, updatedB)
+                .run(() -> bean.addBibliographicKeys(false, updatedB)
                 );
         assertThat(r.getStatus(), is(200));
 
@@ -140,7 +140,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String updatedD = jsonbContext.marshall(d);
 
         Response rd = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, updatedD)
+                .run(() -> bean.addBibliographicKeys(false, updatedD)
                 );
         assertThat(rd.getStatus(), is(200));
     }
@@ -151,7 +151,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String updatedB = jsonbContext.marshall(b);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, updatedB)
+                .run(() -> bean.addBibliographicKeys(false, updatedB)
                 );
         assertThat(r.getStatus(), is(200));
         // Record what time the bib entity was queued
@@ -376,7 +376,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String json = makeBibliographicRequestJson(800000);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, json)
+                .run(() -> bean.addBibliographicKeys(false, json)
                 );
 
         assertThat(r.getStatus(), is(200));
@@ -391,7 +391,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String json = makeBibliographicRequestJson(888000);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, json)
+                .run(() -> bean.addBibliographicKeys(false, json)
                 );
 
         assertThat(r.getStatus(), is(200));
@@ -411,7 +411,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         });
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, json));
+                .run(() -> bean.addBibliographicKeys(false, json));
         assertThat(r.getStatus(), is(200));
         List<BibliographicToBibliographicEntity> l = em.createQuery("SELECT b2b FROM BibliographicToBibliographicEntity as b2b WHERE b2b.liveBibliographicRecordId='new'", BibliographicToBibliographicEntity.class).getResultList();
 
@@ -429,7 +429,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
             e.setBibliographicRecordId("a");
         });
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, a870970));
+                .run(() -> bean.addBibliographicKeys(false, a870970));
         assertThat(r.getStatus(), is(200));
 
         // Setup holding pointint to 870970:a
@@ -448,7 +448,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
             e.setSuperceds(Arrays.asList("a"));
         });
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b870970));
+                .run(() -> bean.addBibliographicKeys(false, b870970));
         assertThat(r.getStatus(), is(200));
 
         // Not really nessecary
@@ -458,7 +458,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
             e.setBibliographicRecordId("a");
         });
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, a870970d));
+                .run(() -> bean.addBibliographicKeys(false, a870970d));
         assertThat(r.getStatus(), is(200));
 
         HoldingsToBibliographicEntity h2bBefore = env().getPersistenceContext()
@@ -474,7 +474,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
             e.setBibliographicRecordId("b");
         });
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, b70000));
+                .run(() -> bean.addBibliographicKeys(false, b70000));
         assertThat(r.getStatus(), is(200));
 
         HoldingsToBibliographicEntity h2bAfter = env().getPersistenceContext()
@@ -491,12 +491,12 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         System.out.println("inconsistentDeletedStatus");
         String a870970 = makeBibliographicRequestJson(
                 870970, e -> {
-                    e.setDeleted(false);
-                    e.setIndexKeys(null);
-                });
+            e.setDeleted(false);
+            e.setIndexKeys(null);
+        });
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, a870970));
+                .run(() -> bean.addBibliographicKeys(false, a870970));
         assertThat(r.getStatus(), not(is(200)));
     }
 
@@ -519,7 +519,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
             e.setDeleted(false);
         });
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, a870970d));
+                .run(() -> bean.addBibliographicKeys(false, a870970d));
         assertThat(r.getStatus(), is(200));
 
         long postDelete = countAndClearQueue();
@@ -527,12 +527,77 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         assertThat(postDelete, is(1L));
 
         r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, a870970));
+                .run(() -> bean.addBibliographicKeys(false, a870970));
         assertThat(r.getStatus(), is(200));
 
         long postResurrect = countAndClearQueue();
         System.out.println("postResurrect = " + postResurrect);
         assertThat(postResurrect, is(1L));
+    }
+
+    @Test(timeout = 2_000L)
+    public void skipQueueParameter() throws Exception {
+        System.out.println("skipQueueParameter");
+
+        Response r;
+
+        long pre = countAndClearQueue();
+        System.out.println("pre = " + pre);
+
+        // live holdings
+        env().getPersistenceContext()
+                .run(() -> env().getEntityManager().merge(
+                        new HoldingsItemEntity(700000, "new", "any",
+                                               new ArrayList<Map<String, List<String>>>() {{
+                                               add(new HashMap<String, List<String>>() {{
+                                                       put("holdingsitem.status", Arrays.asList("OnShelf"));
+                                                   }});
+                                           }}, "test")));
+
+        String a870970 = makeBibliographicRequestJson(
+                870970, e -> {
+        });
+        String a870970d = makeBibliographicRequestJson(
+                870970, e -> {
+                    e.setDeleted(true);
+        });
+        String a700000 = makeBibliographicRequestJson(
+                700000, e -> {
+        });
+        r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(true, a870970));
+        assertThat(r.getStatus(), is(200));
+
+        long postCreate = countAndClearQueue();
+        System.out.println("postCreate = " + postCreate);
+        assertThat(postCreate, is(1L));
+
+        // No changes in structire - nothing queued
+        r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(true, a870970));
+        assertThat(r.getStatus(), is(200));
+
+        long postUpdate = countAndClearQueue();
+        System.out.println("postUpdate = " + postUpdate);
+        assertThat(postUpdate, is(0L));
+
+        // Change in structure
+        r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(true, a700000));
+        assertThat(r.getStatus(), is(200));
+
+        long postMovedHoldings = countAndClearQueue();
+        System.out.println("postMovedHoldings = " + postMovedHoldings);
+        assertThat(postMovedHoldings, is(2L));
+
+        // Delete - change in structure
+        r = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(true, a870970d));
+        assertThat(r.getStatus(), is(200));
+
+        long postDelete = countAndClearQueue();
+        System.out.println("postDelete = " + postDelete);
+        assertThat(postDelete, is(1L));
     }
 
     private void evictAll() throws SQLException {
@@ -564,7 +629,7 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         String deletedB = jsonbContext.marshall(b);
 
         Response r = env().getPersistenceContext()
-                .run(() -> bean.addBibliographicKeys(null, deletedB)
+                .run(() -> bean.addBibliographicKeys(false, deletedB)
                 );
         assertThat(r.getStatus(), is(200));
     }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/DocumentRetrieveBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/DocumentRetrieveBeanIT.java
@@ -52,7 +52,7 @@ public class DocumentRetrieveBeanIT extends JpaSolrDocStoreIntegrationTester {
         hold = createHoldingsItemBean(env);
         h2b = createHoldingsToBibliographicBean(env);
         env().getPersistenceContext().run(() -> {
-            bibl.addBibliographicKeys(new BibliographicEntity(COMMON_AGENCY, "basis", ID, "r:0", "w:0", "u:0", "v0", false, EMPTY, "t0"), Arrays.asList("CBA"));
+            bibl.addBibliographicKeys(new BibliographicEntity(COMMON_AGENCY, "basis", ID, "r:0", "w:0", "u:0", "v0", false, EMPTY, "t0"), Arrays.asList("CBA"), true);
         });
     }
 
@@ -173,7 +173,7 @@ public class DocumentRetrieveBeanIT extends JpaSolrDocStoreIntegrationTester {
         }
 
         private Build record(Map<String, List<String>> content) {
-            bibl.addBibliographicKeys(new BibliographicEntity(holdingsAgencyId, "katalog", holdingsId, "r:*", "w:*", "u:*", "v0", false, content, "t0"), Collections.EMPTY_LIST);
+            bibl.addBibliographicKeys(new BibliographicEntity(holdingsAgencyId, "katalog", holdingsId, "r:*", "w:*", "u:*", "v0", false, content, "t0"), Collections.EMPTY_LIST, true);
             return this;
         }
     }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/EnqueueSupplierBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/EnqueueSupplierBeanIT.java
@@ -345,13 +345,13 @@ public class EnqueueSupplierBeanIT extends JpaSolrDocStoreIntegrationTester {
     private BibliographicEntity addBibliographic(int agency, String classifier, String bibliographicRecordId, Optional<List<String>> superseed, Optional commitWithin) {
         List<String> superseedList = superseed.orElse(Collections.emptyList());
         BibliographicEntity e = new BibliographicEntity(agency, classifier, bibliographicRecordId, "id#1", "w", "u", "v0.1", false, Collections.EMPTY_MAP, "IT");
-        bibliographicBean.addBibliographicKeys(e, superseedList, commitWithin);
+        bibliographicBean.addBibliographicKeys(e, superseedList, commitWithin, true);
         return e;
     }
 
     private void deleteBibliographic(BibliographicEntity ownRecord) {
         ownRecord.setDeleted(true);
-        bibliographicBean.addBibliographicKeys(ownRecord, Collections.emptyList(), Optional.empty());
+        bibliographicBean.addBibliographicKeys(ownRecord, Collections.emptyList(), Optional.empty(), true);
     }
 
     private HoldingsItemEntity addHoldings(int holdingAgency, String holdingBibliographicId) {

--- a/service/src/test/java/dk/dbc/search/solrdocstore/QueueAsyncJobIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/QueueAsyncJobIT.java
@@ -139,13 +139,13 @@ public class QueueAsyncJobIT extends JpaSolrDocStoreIntegrationTester {
     private void setupData() {
         env().getPersistenceContext().run(() -> {
             for (int i = 0 ; i < 10 ; i++) {
-                bibl.addBibliographicKeys(makeBiblEntity(700000, "a" + i), Collections.EMPTY_LIST);
-                bibl.addBibliographicKeys(makeBiblEntity(700000, "b" + i), Collections.EMPTY_LIST);
-                bibl.addBibliographicKeys(makeBiblEntity(700000, "c" + i), Collections.EMPTY_LIST);
+                bibl.addBibliographicKeys(makeBiblEntity(700000, "a" + i), Collections.EMPTY_LIST, true);
+                bibl.addBibliographicKeys(makeBiblEntity(700000, "b" + i), Collections.EMPTY_LIST, true);
+                bibl.addBibliographicKeys(makeBiblEntity(700000, "c" + i), Collections.EMPTY_LIST, true);
             }
             BibliographicEntity entity = makeBiblEntity(700001, "dd");
             entity.setDeleted(true);
-            bibl.addBibliographicKeys(entity, Collections.EMPTY_LIST);
+            bibl.addBibliographicKeys(entity, Collections.EMPTY_LIST, true);
         });
         clearQueue(dataSource);
     }


### PR DESCRIPTION
No need to reindex records that hasn't changed