### PR TITLE
Redeployed deleted manifestation fails

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -153,7 +153,7 @@ public class BibliographicBean {
             }
             // If we delete or re-create, related holdings must be moved appropriately
             if (bibliographicEntity.isDeleted() != dbbe.isDeleted()) {
-                if(!queueAll) {
+                if (!queueAll) {
                     // The record, changed delete status - should not respect the skipQueue flag
                     enqueue = enqueueSupplier.getEnqueueCollector();
                 }
@@ -181,7 +181,11 @@ public class BibliographicBean {
                     h2bBean.tryToAttachToBibliographicRecord(relatedHolding.getHoldingsAgencyId(), relatedHolding.getHoldingsBibliographicRecordId(), enqueue, QueueType.MANIFESTATION);
                 }
             } else {
-                enqueue.add(bibliographicEntity, QueueType.MANIFESTATION, QueueType.WORK);
+                if (bibliographicEntity.isDeleted()) {
+                    enqueue.add(bibliographicEntity, QueueType.MANIFESTATION);
+                } else {
+                    enqueue.add(bibliographicEntity, QueueType.MANIFESTATION, QueueType.WORK);
+                }
                 // Simple update
                 entityManager.merge(bibliographicEntity.asBibliographicEntity());
             }

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -181,9 +181,8 @@ public class BibliographicBean {
                     h2bBean.tryToAttachToBibliographicRecord(relatedHolding.getHoldingsAgencyId(), relatedHolding.getHoldingsBibliographicRecordId(), enqueue, QueueType.MANIFESTATION);
                 }
             } else {
-                if (bibliographicEntity.isDeleted()) {
-                    enqueue.add(bibliographicEntity, QueueType.MANIFESTATION);
-                } else {
+                // Going fro deleted to deleted shouldn't result in queue jobs
+                if (!bibliographicEntity.isDeleted()) {
                     enqueue.add(bibliographicEntity, QueueType.MANIFESTATION, QueueType.WORK);
                 }
                 // Simple update

--- a/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/BibliographicBean.java
@@ -181,7 +181,7 @@ public class BibliographicBean {
                     h2bBean.tryToAttachToBibliographicRecord(relatedHolding.getHoldingsAgencyId(), relatedHolding.getHoldingsBibliographicRecordId(), enqueue, QueueType.MANIFESTATION);
                 }
             } else {
-                // Going fro deleted to deleted shouldn't result in queue jobs
+                // Going from deleted to deleted shouldn't result in queue jobs
                 if (!bibliographicEntity.isDeleted()) {
                     enqueue.add(bibliographicEntity, QueueType.MANIFESTATION, QueueType.WORK);
                 }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/BibliographicBeanIT.java
@@ -146,10 +146,17 @@ public class BibliographicBeanIT extends JpaSolrDocStoreIntegrationTester {
         BibliographicEntity d = new BibliographicEntity(600100, "clazzifier", "properUpdate", "id#2", null, null, "prod:update", true, makeIndexKeys(), "track:update");
         String updatedD = jsonbContext.marshall(d);
 
-        Response rd = env().getPersistenceContext()
+        Response rd1 = env().getPersistenceContext()
                 .run(() -> bean.addBibliographicKeys(false, updatedD)
                 );
-        assertThat(rd.getStatus(), is(200));
+        assertThat(rd1.getStatus(), is(200));
+
+        // resend deleted record:
+        Response rd2 = env().getPersistenceContext()
+                .run(() -> bean.addBibliographicKeys(false, updatedD)
+                );
+        assertThat(rd2.getStatus(), is(200));
+
     }
 
     @Test


### PR DESCRIPTION
When a record is deployed, and it doesn't change state, then if it is a delete record, the work-id is null, and that cannot be enqueued.
