### PR TITLE
Delayed startup for cachemanager initialization

### DIFF
--- a/solr-updater/src/main/docker/Dockerfile
+++ b/solr-updater/src/main/docker/Dockerfile
@@ -33,7 +33,8 @@ LABEL SOLR_URL="(zk-/httpurl[=features]) (semicolon seperated list) of solr-coll
       JSON_STASH="Path for storing posted documents as JSON for generating test data (optional)" \
       CACHE_TIMEOUT="profile-service cache timeout in seconds (default: 60)" \
       SCAN_PROFILES="Comma separated list of {agency}-{profile}, that can scan (required)" \
-      SCAN_DEFAULT_FIELDS="COmma separated list of scan.field that scan.ddefault covers (required)" \
+      SCAN_DEFAULT_FIELDS="Comma separated list of scan.field that scan.ddefault covers (required)" \
+      STARTUP_DELAY="Wait duration before starting harvesting (default: 5s)" \
       USER_AGENT="Useragent string to use for http-client" \
       SCOPE="Name of service (for cache identification)" \
       COLLECTION="Name of collection (for cache identification)" \

--- a/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/Config.java
+++ b/solr-updater/src/main/java/dk/dbc/search/solrdocstore/updater/Config.java
@@ -46,6 +46,7 @@ public class Config {
     private Set<SolrCollection> solrCollections;
     private String solrDocStoreUrl;
 
+    private long startupDelay;
     private String[] queues;
     private String databaseConnectThrottle;
     private String failureThrottle;
@@ -94,6 +95,7 @@ public class Config {
                 }).build();
         solrCollections = makeSolrCollections(client);
         solrDocStoreUrl = get("solrDocStoreUrl", "SOLR_DOC_STORE_URL", null);
+        startupDelay = Long.max(100L, milliseconds(get("startupDelay", "STARTUP_DELAY", "5s")));
         queues = toCollection(get("queues", "QUEUES", null)).toArray(String[]::new);
         databaseConnectThrottle = get("databaseConnectThrottle", "DATABASE_CONNECT_THROTTLE", "1/s,5/m");
         failureThrottle = get("failureThrottle", "FAILURE_THROTTLE", "2/100ms,5/500ms,10/s,20/m");
@@ -177,6 +179,10 @@ public class Config {
 
     public String getSolrDocStoreUrl() {
         return solrDocStoreUrl;
+    }
+
+    public long getStartupDelay() {
+        return startupDelay;
     }
 
     public String[] getQueues() {


### PR DESCRIPTION
To mitigate
```
java.lang.IllegalStateException: Cannot overwrite a Cache's CacheManager.
```
Exceptions when queue is full, and dequeuing/processing is started before the cache manager (LibraryRuleProvider)  is ready.
