### PR TITLE
Di-1592 solr-doc-store service v2/resource fejler ved escapede kolon karakter

### DIFF
--- a/service/src/main/java/dk/dbc/search/solrdocstore/v2/ResourceBeanV2.java
+++ b/service/src/main/java/dk/dbc/search/solrdocstore/v2/ResourceBeanV2.java
@@ -91,7 +91,7 @@ public class ResourceBeanV2 {
     @PUT
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
-    @Path("{fieldName}/{agencyId}:{bibliographicRecordId}")
+    @Path("{fieldName}/{agencyId}{separator: :|%3A|%3a}{bibliographicRecordId}")
     @Operation(
             operationId = "add/update-resource",
             summary = "Adds/updates/removes a resource to/from an item",
@@ -121,7 +121,7 @@ public class ResourceBeanV2 {
     @DELETE
     @Consumes({MediaType.APPLICATION_JSON})
     @Produces({MediaType.APPLICATION_JSON})
-    @Path("{fieldName}/{agencyId}:{bibliographicRecordId}")
+    @Path("{fieldName}/{agencyId}{separator: :|%3A|%3a}{bibliographicRecordId}")
     @Operation(
             operationId = "delete-resource",
             summary = "Removes a resource to an item",

--- a/service/src/test/java/dk/dbc/search/solrdocstore/ServiceIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/ServiceIT.java
@@ -45,5 +45,10 @@ public class ServiceIT extends ServiceTester {
                 .as(DocumentRetrieveResponse.class);
         assertThat(withoutHoldings.bibliographicRecord.getRepositoryId(), is("870970-basis:25912233"));
         assertThat(withoutHoldings.holdingsItemRecords, empty());
+
+        // Test api/v2/resource/hasFBICoverUrl/710100%3A38622617 with and witout escaping
+        // @Path("{fieldName}/{agencyId}:{bibliographicRecordId}")
+        put(apiV2("resources", "hasFBICoverUrl", "870970:38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK);
+        put(apiV2("resources", "hasFBICoverUrl", "870970%3A38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK); // 404 not found
     }
 }

--- a/service/src/test/java/dk/dbc/search/solrdocstore/ServiceIT.java
+++ b/service/src/test/java/dk/dbc/search/solrdocstore/ServiceIT.java
@@ -45,10 +45,30 @@ public class ServiceIT extends ServiceTester {
                 .as(DocumentRetrieveResponse.class);
         assertThat(withoutHoldings.bibliographicRecord.getRepositoryId(), is("870970-basis:25912233"));
         assertThat(withoutHoldings.holdingsItemRecords, empty());
+    }
 
-        // Test api/v2/resource/hasFBICoverUrl/710100%3A38622617 with and witout escaping
-        // @Path("{fieldName}/{agencyId}:{bibliographicRecordId}")
-        put(apiV2("resources", "hasFBICoverUrl", "870970:38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK);
-        put(apiV2("resources", "hasFBICoverUrl", "870970%3A38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK); // 404 not found
+    @Test
+    public void testResources() throws Exception {
+        System.out.println("testResources");
+
+        post(apiV2("bibliographic"))
+                .send(Doc.bibliographic("38622617")
+                        .indexKeys("{" +
+                                   "'id':'870970-38622617'," +
+                                   "'rec.collectionIdentifier':['870970-basis']" +
+                                   "}")
+                        .json())
+                .statusIs(Response.Status.OK);
+
+        // Test api/v2/resource/hasFBICoverUrl/870970%3A38622617 with and witout escaping
+        // @Path("{fieldName}/{agencyId}{separator: :|%3A|%3a}{bibliographicRecordId}")
+        put(apiV2("resource", "hasFBICoverUrl", "870970:38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK);
+        delete(apiV2("resource", "hasFBICoverUrl", "870970:38622617") ).statusIs(Response.Status.OK);
+
+        put(apiV2("resource", "hasFBICoverUrl", "870970%3A38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK);
+        delete(apiV2("resource", "hasFBICoverUrl", "870970%3A38622617") ).statusIs(Response.Status.OK);
+
+        put(apiV2("resource", "hasFBICoverUrl", "870970%3a38622617") ).send("{\"has\":true}").statusIs(Response.Status.OK);
+        delete(apiV2("resource", "hasFBICoverUrl", "870970%3a38622617") ).statusIs(Response.Status.OK);
     }
 }


### PR DESCRIPTION
api/v2/resource/hasFBICoverUrl/800010:99122127298505763 PUT/DELETE fejler med en 404 statuskode hvis ':' erstattes erstattes med '%3A' eller '%3a' i URL'en (som kafka-to-webservice bruger)